### PR TITLE
Enable CORS for video uploads

### DIFF
--- a/index.html
+++ b/index.html
@@ -1448,6 +1448,7 @@
 
         const response = await fetch(CONFIG.SHEETS_URL, {
           method: 'POST',
+          mode: 'cors',
           headers: {
             'Content-Type': 'application/json',
           },
@@ -1467,6 +1468,10 @@
         return result;
 
       } catch (error) {
+        if (error instanceof TypeError) {
+          console.error('Drive upload error: CORS or network issue', error);
+          return { success: false, error: 'Network or CORS error' };
+        }
         console.error('Drive upload error:', error);
         return { success: false, error: error.message };
       }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,41 @@
+// Simple Node server to handle video uploads with proper CORS headers.
+// This server responds with JSON and exposes the required CORS headers so
+// that the front-end fetch call in index.html can succeed when using
+// `mode: 'cors'`.
+
+const http = require('http');
+
+const server = http.createServer((req, res) => {
+  // Handle CORS preflight requests
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204, {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type'
+    });
+    return res.end();
+  }
+
+  if (req.method !== 'POST') {
+    res.writeHead(405, { 'Access-Control-Allow-Origin': '*' });
+    return res.end();
+  }
+
+  let body = '';
+  req.on('data', chunk => { body += chunk; });
+  req.on('end', () => {
+    // Process the body as needed. For this example we simply acknowledge
+    // receipt of the data.
+    res.writeHead(200, {
+      'Access-Control-Allow-Origin': '*',
+      'Content-Type': 'application/json'
+    });
+    res.end(JSON.stringify({ success: true }));
+  });
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});
+


### PR DESCRIPTION
## Summary
- use explicit `mode: 'cors'` for Drive upload requests and handle network/CORS errors
- add example Node server that returns `Access-Control-Allow-Origin` and JSON content type headers

## Testing
- `node server.js &` *(ran server)*
- `curl -i -X POST http://localhost:3000 -H "Content-Type: application/json" -d '{}'`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689df93489308326a9f5101886ba77fc