### PR TITLE
Add final completion step

### DIFF
--- a/google-apps-script.gs
+++ b/google-apps-script.gs
@@ -5,6 +5,9 @@ function doPost(e) {
     case 'aslct_issue':
       logASLCTIssue(data);
       break;
+    case 'study_completed':
+      markStudyComplete(data);
+      break;
     // other cases...
     default:
       result = { status: 'unknown_action' };
@@ -28,4 +31,33 @@ function logASLCTIssue(data) {
     'ASLCT Issue Reported',
     'Session Code: ' + data.sessionCode + '\nParticipant ID: ' + data.participantID + '\nMessage: ' + data.message
   );
+}
+
+function markStudyComplete(data) {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const sheet = ss.getSheetByName('Sessions');
+  if (!sheet) return;
+
+  const rows = sheet.getDataRange().getValues();
+  for (let i = 1; i < rows.length; i++) {
+    if (rows[i][0] === data.sessionCode) {
+      const deviceType = rows[i][11] ? rows[i][11].toString() : '';
+      const totalTasks = deviceType.toLowerCase().includes('mobile') ? 6 : 7;
+
+      sheet.getRange(i + 1, 6).setValue(data.timestamp || new Date().toISOString());
+      if (data.totalDuration !== undefined) {
+        sheet.getRange(i + 1, 7).setValue(data.totalDuration);
+      }
+      sheet.getRange(i + 1, 8).setValue(totalTasks + '/' + totalTasks);
+
+      const consent1 = sheet.getRange(i + 1, 9);
+      if (consent1.getValue() !== 'Declined') consent1.setValue('Complete');
+
+      const consent2 = sheet.getRange(i + 1, 10);
+      if (consent2.getValue() !== 'Declined') consent2.setValue('Complete');
+
+      sheet.getRange(i + 1, 11).setValue('Complete');
+      break;
+    }
+  }
 }

--- a/index.html
+++ b/index.html
@@ -474,7 +474,12 @@
             <div class="code" id="final-code">ABC12345</div>
           </div>
           <p style="margin-top: 20px;">Total time: <strong id="total-time">0</strong> minutes</p>
-          <p style="margin-top: 30px; color: var(--text-muted);">You may now close this window.</p>
+          <div class="button-group" style="margin-top:30px;">
+            <button class="button success" id="mark-complete-btn" onclick="markComplete()">Mark Me Complete</button>
+          </div>
+          <p id="completion-message" style="display:none; margin-top:20px; color: var(--text-muted);">
+            ✅ Your participation has been recorded. You may now close this window.
+          </p>
         </div>
       </div>
     </div>
@@ -1647,15 +1652,21 @@ function updateUploadProgress(percent, message) {
     function showCompletionScreen() {
       document.getElementById('final-code').textContent = state.sessionCode;
       document.getElementById('total-time').textContent = Math.round(state.totalTimeSpent / 60000);
-      sendToSheets({
+      showScreen('completion-screen');
+      document.getElementById('pause-fab').classList.remove('active');
+    }
+
+    async function markComplete() {
+      const btn = document.getElementById('mark-complete-btn');
+      btn.disabled = true;
+      await sendToSheets({
         action: 'study_completed',
         sessionCode: state.sessionCode,
         totalDuration: Math.round(state.totalTimeSpent / 60000),
         deviceType: state.isMobile ? 'mobile/tablet' : 'desktop',
         timestamp: new Date().toISOString()
       });
-      showScreen('completion-screen');
-      document.getElementById('pause-fab').classList.remove('active');
+      document.getElementById('completion-message').style.display = 'block';
     }
 
     // ----- Utilities -----
@@ -1880,6 +1891,7 @@ function updateUploadProgress(percent, message) {
     window.continueWithoutUpload = continueWithoutUpload;
      window.debugVideoUpload = debugVideoUpload;
     window.submitASLCTIssue = submitASLCTIssue;
+    window.markComplete = markComplete;
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add "Mark Me Complete" button so participants explicitly finalize sessions.
- Handle `study_completed` action in Apps Script, marking consents and session status as complete.

## Testing
- `node --version`
- `node server.js & sleep 1; kill $!`


------
https://chatgpt.com/codex/tasks/task_e_68a3d17572fc8326a68d491f4687a1c1