### PR TITLE
Fix navigation stuck on initial page by removing extra brace

### DIFF
--- a/index.html
+++ b/index.html
@@ -1577,10 +1577,6 @@ async function uploadVideoToDrive(videoBlob, sessionCode, imageNumber) {
   }
 }
 
-   
-
-}
-
     // Add this NEW function after uploadVideoToDrive
 function updateUploadProgress(percent, message) {
   const progressDiv = document.getElementById('upload-progress');


### PR DESCRIPTION
## Summary
- Remove stray closing brace after `uploadVideoToDrive` to restore JavaScript execution and allow screen changes

## Testing
- `node --check script.js`
- `node --check server.js`


------
https://chatgpt.com/codex/tasks/task_e_68a3f57f5df48326a07a25d9d65839c1