### PR TITLE
feat: add WIAT reading comprehension for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -686,7 +686,7 @@ const CODE_REGEX = /^\d{6}$/; // six digits from Qualtrics code
 
     // ----- Tasks -----
     const TASKS = {
-  'RC':  { name:'Reading Comprehension Task', description:'Read passages and answer questions', type:'embed', embedUrl:'https://melodyfschwenk.github.io/readingcomp/', canSkip:true, estMinutes:15, requirements:'None' },
+  'WIAT': { name:'Reading Comprehension (WIAT)', description:'Read passages and answer questions', type:'embed', embedUrl:'https://melodyfschwenk.github.io/readingcomp/', canSkip:true, estMinutes:15, requirements:'None' },
   'MRT': { name:'Mental Rotation Task', description:'Decide if two images are the same or not', type:'embed', embedUrl:'https://melodyfschwenk.github.io/mrt/', canSkip:true, estMinutes:6,  requirements:'Keyboard recommended' },
   'ASLCT': { name:'ASL Comprehension Test', description:'For ASL users only', url:'https://vl2portal.gallaudet.edu/assessment/', type:'external', canSkip:true, estMinutes:15, requirements:'ASL users; stable connection' },
   'VCN': { name:'Virtual Campus Navigation', description:'Virtual SILC Test of Navigation (SILCton)', url:'http://www.virtualsilcton.com/study/753798747', type:'external', canSkip:true, estMinutes:20, requirements:'Desktop/laptop; keyboard (WASD) & mouse' },
@@ -710,8 +710,8 @@ const CODE_REGEX = /^\d{6}$/; // six digits from Qualtrics code
     };
 
     // ----- Task sequencing -----
-    const DESKTOP_TASKS = ['RC', 'MRT', 'ASLCT', 'VCN', 'SN', 'ID'];
-    const MOBILE_TASKS = ['RC', 'MRT', 'ASLCT', 'SN', 'ID'];
+    const DESKTOP_TASKS = ['WIAT', 'MRT', 'ASLCT', 'VCN', 'SN', 'ID'];
+    const MOBILE_TASKS = ['WIAT', 'MRT', 'ASLCT', 'SN', 'ID'];
 
     function mulberry32(a) {
       return function() {


### PR DESCRIPTION
## Summary
- rename Reading Comprehension task to WIAT and include it in both desktop and mobile sequences

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a86f8a128c8326b9e65a235a00b8aa