### PR TITLE
Reorganize EEG section on welcome page

### DIFF
--- a/index.html
+++ b/index.html
@@ -306,7 +306,7 @@
     <div>
       <h4 style="margin-bottom: 8px; font-weight: 600;">Need help?</h4>
       <p style="margin: 0; color: inherit;">
-        Having technical issues or need accommodations? 
+        Having technical issues or need accommodations?
         <strong>We're here to help you succeed!</strong>
       </p>
       <div style="margin-top: 12px;">
@@ -316,58 +316,6 @@
       </div>
     </div>
   </div>
-
-  <!-- EEG section - prominent but friendly -->
-  <div class="card" style="margin-top: 32px; border: 2px solid var(--info); background: linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%);">
-    <div style="text-align: center;">
-      <div style="font-size: 48px; margin-bottom: 16px;">🧠</div>
-      <h3 style="margin-bottom: 12px; font-size: 22px; color: var(--primary-dark);">
-        EEG Brain Recording Session
-      </h3>
-      <p style="color: var(--text-primary); margin-bottom: 16px; font-size: 16px;">
-        <strong>DC/MD/VA area participants:</strong> We'd love to include you in our EEG component! 
-        It's a fascinating 30-45 minute session where we record your brain activity.
-      </p>
-      
-      <div class="info-box helpful" style="text-align: left; background: rgba(255,255,255,0.7); margin: 16px 0;">
-        <div class="icon">⭐</div>
-        <div>
-          <h4 style="margin-bottom: 8px; font-weight: 600;">Why EEG matters for this research</h4>
-          <ul style="margin: 8px 0 0 0; padding-left: 16px; color: inherit;">
-            <li>Captures real-time brain responses to spatial tasks</li>
-            <li>Helps us understand how deaf and hearing brains process space differently</li>
-            <li><strong>Great compensation:</strong> $25/hour for online + $25/hour for EEG (minimum $50 total!)</li>
-            <li>ASL or spoken English available</li>
-          </ul>
-        </div>
-      </div>
-
-      <div class="info-box friendly-tip" style="text-align: left; background: rgba(255,255,255,0.7); margin: 16px 0;">
-        <div class="icon">📅</div>
-        <div>
-          <h4 style="margin-bottom: 8px; font-weight: 600;">Flexible scheduling</h4>
-          <p style="margin: 0; color: inherit;">
-            You can schedule now or after completing your online tasks. 
-            <strong>Our lab space is changing soon</strong>, so earlier scheduling is appreciated!
-          </p>
-        </div>
-      </div>
-
-      <div class="button-group" style="margin-top: 20px;">
-        <button class="button success" onclick="scheduleEEG()" style="font-size: 16px; padding: 14px 28px;">
-          🗓️ Schedule My EEG Session
-        </button>
-        <button class="button friendly" onclick="markEEGScheduled()">
-          ✓ I Already Scheduled
-        </button>
-      </div>
-      
-      <p style="margin-top: 12px; font-size: 14px; color: var(--text-secondary);">
-        Not in the DC area? No problem! You can still participate in the online portion.
-      </p>
-    </div>
-  </div>
-
   <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-top: 32px;">
     <div class="card">
       <div style="text-align: center;">
@@ -393,6 +341,56 @@
           Resume Session →
         </button>
       </div>
+    </div>
+  </div>
+
+  <!-- EEG section - prominent but friendly -->
+  <div class="card" style="margin-top: 32px; border: 2px solid var(--info); background: linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%);">
+    <div style="text-align: center;">
+      <div style="font-size: 48px; margin-bottom: 16px;">🧠</div>
+      <h3 style="margin-bottom: 12px; font-size: 22px; color: var(--primary-dark);">
+        EEG Session
+      </h3>
+      <p style="color: var(--text-primary); margin-bottom: 16px; font-size: 16px;">
+        <strong>DC/MD/VA area participants:</strong> We'd love to include you in our EEG component! EEG uses small sensors on your scalp to measure brain activity during tasks. The session takes about 30-45 minutes.
+      </p>
+
+      <div class="info-box helpful" style="text-align: left; background: rgba(255,255,255,0.7); margin: 16px 0;">
+        <div class="icon">⭐</div>
+        <div>
+          <h4 style="margin-bottom: 8px; font-weight: 600;">Why EEG matters for this research</h4>
+          <ul style="margin: 8px 0 0 0; padding-left: 16px; color: inherit;">
+            <li>Captures real-time brain responses to spatial tasks</li>
+            <li>Helps us understand how deaf and hearing brains process space differently</li>
+            <li><strong>Great compensation:</strong> $25/hour for online + $25/hour for EEG (minimum $50 total!)</li>
+            <li>ASL or spoken English available</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="info-box friendly-tip" style="text-align: left; background: rgba(255,255,255,0.7); margin: 16px 0;">
+        <div class="icon">📅</div>
+        <div>
+          <h4 style="margin-bottom: 8px; font-weight: 600;">Flexible scheduling</h4>
+          <p style="margin: 0; color: inherit;">
+            You can schedule now or after completing your online tasks.
+            <strong>Our lab space is changing soon</strong>, so earlier scheduling is appreciated!
+          </p>
+        </div>
+      </div>
+
+      <div class="button-group" style="margin-top: 20px;">
+        <button class="button success" onclick="scheduleEEG()" style="font-size: 16px; padding: 14px 28px;">
+          🗓️ Schedule My EEG Session
+        </button>
+        <button class="button friendly" onclick="markEEGScheduled()">
+          ✓ I Already Scheduled
+        </button>
+      </div>
+
+      <p style="margin-top: 12px; font-size: 14px; color: var(--text-secondary);">
+        Not in the DC area? No problem! You can still participate in the online portion.
+      </p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Move EEG scheduling card beneath new/returning participant options
- Tone down EEG card wording and add plain-language explanation of EEG

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a91706937c8326aa2759a9e106da3f