### PR TITLE
Clarify EEG and online compensation

### DIFF
--- a/index.html
+++ b/index.html
@@ -362,7 +362,7 @@
           <ul style="margin: 8px 0 0 0; padding-left: 16px; color: inherit;">
             <li>Captures real-time brain responses to spatial tasks</li>
             <li>Helps us understand how deaf and hearing brains process space differently</li>
-            <li><strong>Great compensation:</strong> $25/hour for online + $25/hour for EEG (minimum $50 total!)</li>
+            <li><strong>Compensation:</strong> $25 for the online portion and $25 for the EEG session (about $50 total), with additional pay if the EEG session runs longer than expected.</li>
             <li>ASL or spoken English available</li>
           </ul>
         </div>


### PR DESCRIPTION
## Summary
- detail compensation as $25 for the online portion and $25 for the EEG session with extra pay if the EEG runs long

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9185f16dc8326bdf188af32f3223a