### PR TITLE
Fix syntax error in video recording log

### DIFF
--- a/google-apps-script.gs
+++ b/google-apps-script.gs
@@ -1194,7 +1194,7 @@ function logVideoRecording(ss, data) {
     data.sessionCode,
     data.participantID || '',
     'Image Description',
-    'Video Recorded - Image ' + data.imageNumber',
+    'Video Recorded - Image ' + data.imageNumber,
     '',
     '',
     0,


### PR DESCRIPTION
## Summary
- Correct stray quote in `logVideoRecording` to maintain valid syntax.

## Testing
- `node --check google-apps-script.js`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acce176e388326827a9ab09ab6b398