### PR TITLE
Normalize task names for accurate completion counts

### DIFF
--- a/index.html
+++ b/index.html
@@ -838,6 +838,7 @@ const CODE_REGEX = /^\d{6}$/; // six digits from Qualtrics code
     // Add this after TASKS definition
     function getStandardTaskName(taskCode) {
       const mapping = {
+        'WIAT': 'Reading Comprehension Task',
         'RC': 'Reading Comprehension Task',
         'MRT': 'Mental Rotation Task',
         'ASLCT': 'ASL Comprehension Test',


### PR DESCRIPTION
## Summary
- Map WIAT code to standardized task name so frontend logs use consistent label
- Normalize task names in Apps Script and recompute `Tasks Completed` using normalized values

## Testing
- `node --check google-apps-script.gs` *(fails: Unknown file extension ".gs")*
- `npx htmlhint index.html` *(fails: npm error canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68adcfd152208326a9063c29b2c9ad3e