### PR TITLE
Normalize task names for accurate completion counts

### DIFF
--- a/google-apps-script.gs
+++ b/google-apps-script.gs
@@ -1407,14 +1407,28 @@ function updateTotalTime(ss, sessionCode) {
 
 function normalizeTaskName_(name) {
   var map = {
+    // Collapse all reading comprehension labels to WIAT
     'Reading Comprehension (WIAT)': 'WIAT',
     'Reading Comprehension Task': 'WIAT',
+    'WIAT': 'WIAT',
+
     'Mental Rotation Task': 'MRT',
+    'MRT': 'MRT',
+
     'ASL Comprehension Test': 'ASLCT',
+    'ASLCT': 'ASLCT',
+
     'Virtual Campus Navigation': 'VCN',
+    'VCN': 'VCN',
+
     'Spatial Navigation': 'SN',
+    'SN': 'SN',
+
     'Image Description': 'ID',
-    'Demographics Survey': 'DEMO'
+    'ID': 'ID',
+
+    'Demographics Survey': 'DEMO',
+    'DEMO': 'DEMO'
   };
   return map[name] || name;
 }

--- a/index.html
+++ b/index.html
@@ -654,7 +654,7 @@
           <div class="video-container">
             <div class="video-panel">
               <h3>Image to Describe</h3>
-              <img id="current-image" src="" alt="Image to describe" style="width: 100%; border-radius: 10px;" />
+              <img id="current-image" src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="Image to describe" style="width: 100%; border-radius: 10px;" />
             </div>
 
             <div class="video-panel">
@@ -835,7 +835,6 @@ const CODE_REGEX = /^\d{6}$/; // six digits from Qualtrics code
 },
   'DEMO':{ name:'Demographics Survey', description:'Background information & payment', url:'https://gallaudet.iad1.qualtrics.com/jfe/form/SV_8GJcoF3hkHoP8BU', type:'external', estMinutes:6, requirements:'None' }
 };
-    // Add this after TASKS definition
     function getStandardTaskName(taskCode) {
       const mapping = {
         'WIAT': 'WIAT',

--- a/index.html
+++ b/index.html
@@ -269,7 +269,7 @@
           </div>
           <div class="session-detail">
             <label>Progress</label>
-            <div class="value" id="widget-progress">0/7</div>
+        <div class="value" id="widget-progress">0/0</div>
           </div>
           <div class="session-detail">
             <label>Time Spent</label>
@@ -838,15 +838,15 @@ const CODE_REGEX = /^\d{6}$/; // six digits from Qualtrics code
     // Add this after TASKS definition
     function getStandardTaskName(taskCode) {
       const mapping = {
-        'RC': 'Reading Comprehension Task',
-        'MRT': 'Mental Rotation Task',
-        'ASLCT': 'ASL Comprehension Test',
-        'VCN': 'Virtual Campus Navigation',
-        'SN': 'Spatial Navigation',
-        'ID': 'Image Description',
-        'DEMO': 'Demographics Survey'
+        'WIAT': 'WIAT',
+        'MRT': 'MRT',
+        'ASLCT': 'ASLCT',
+        'VCN': 'VCN',
+        'SN': 'SN',
+        'ID': 'ID',
+        'DEMO': 'DEMO'
       };
-      return mapping[taskCode] || TASKS[taskCode]?.name || taskCode;
+      return mapping[taskCode] || taskCode;
     }
 
     // ----- Consents -----
@@ -1079,19 +1079,23 @@ function handleDropboxAuth() {
 // Call on page load
 document.addEventListener('DOMContentLoaded', () => {
   handleDropboxAuth();
-      setupEventListeners();
-      // Secure-context guard: disable inline recording if not https
-if (!window.isSecureContext) {
-  // Hide the record button if the recording screen gets opened
-  const style = document.createElement('style');
-  style.textContent = `#record-btn { display: none !important; }`;
-  document.head.appendChild(style);
-}
+  setupEventListeners();
 
-      checkSavedSession();
+  const widgetProgress = document.getElementById('widget-progress');
+  if (widgetProgress) widgetProgress.textContent = `0/${isMobileDevice() ? 6 : 7}`;
 
-      // Gentle mobile notice content swap
-      if (isMobileDevice()) {
+  // Secure-context guard: disable inline recording if not https
+  if (!window.isSecureContext) {
+    // Hide the record button if the recording screen gets opened
+    const style = document.createElement('style');
+    style.textContent = `#record-btn { display: none !important; }`;
+    document.head.appendChild(style);
+  }
+
+  checkSavedSession();
+
+  // Gentle mobile notice content swap
+  if (isMobileDevice()) {
         const warning = document.getElementById('device-warning');
         if (warning) {
           warning.className = 'info-box friendly-tip';


### PR DESCRIPTION
## Summary
- Standardize task code mapping so WIAT uniquely represents the reading comprehension task
- Send task codes from frontend and normalize names in Apps Script for consistent counting
- Record Image Description events with task code ID for uniform tracking

## Testing
- `node --check google-apps-script.gs` *(fails: Unknown file extension ".gs")*
- `npx htmlhint index.html` *(fails: The attribute [ src ] of the tag [ img ] must have a value)*

------
https://chatgpt.com/codex/tasks/task_e_68adcfd152208326a9063c29b2c9ad3e