### PR TITLE
Replace WIAT with RC reading comprehension task

### DIFF
--- a/google-apps-script.gs
+++ b/google-apps-script.gs
@@ -513,11 +513,11 @@ function safeSetupOrMigrate_() {
 
   // Score tracking
   ensureSheetWithHeaders_(ss, 'ASLCT Scores', ['Session Code','ASLCT Score','Entry Time','Notes']);
-  ensureSheetWithHeaders_(ss, 'WIAT Scores', ['Session Code','WIAT Score','Entry Time','Notes']);
-  var summary = ensureSheetWithHeaders_(ss, 'Scores Summary', ['Session Code','ASLCT Score','WIAT Score']);
+  ensureSheetWithHeaders_(ss, 'RC Scores', ['Session Code','RC Score','Entry Time','Notes']);
+  var summary = ensureSheetWithHeaders_(ss, 'Scores Summary', ['Session Code','ASLCT Score','RC Score']);
   if (summary.getLastRow() < 2) {
     summary.getRange('B2').setFormula('=ARRAYFORMULA(IF(A2:A="",,IFERROR(VLOOKUP(A2:A,\'ASLCT Scores\'!A:B,2,false),"")))');
-    summary.getRange('C2').setFormula('=ARRAYFORMULA(IF(A2:A="",,IFERROR(VLOOKUP(A2:A,\'WIAT Scores\'!A:B,2,false),"")))');
+    summary.getRange('C2').setFormula('=ARRAYFORMULA(IF(A2:A="",,IFERROR(VLOOKUP(A2:A,\'RC Scores\'!A:B,2,false),"")))');
   }
 
   // Dynamic columns + dashboard
@@ -554,8 +554,8 @@ function safeSetupOrMigrate_() {
   dash.getRange('A15').setValue('Score Entries');
   dash.getRange('A16').setValue('ASLCT Scores Entered');
   dash.getRange('B16').setFormula('=COUNTA(\'ASLCT Scores\'!A2:A)');
-  dash.getRange('A17').setValue('WIAT Scores Entered');
-  dash.getRange('B17').setFormula('=COUNTA(\'WIAT Scores\'!A2:A)');
+  dash.getRange('A17').setValue('RC Scores Entered');
+  dash.getRange('B17').setFormula('=COUNTA(\'RC Scores\'!A2:A)');
 
   dash.getRange('A19').setValue('EEG Interested');
   var eegStatusCol = sessionsSheet.getRange(1, eegCols.status).getA1Notation().replace(/[0-9]/g, '');
@@ -1407,7 +1407,7 @@ function updateTotalTime(ss, sessionCode) {
 
 function normalizeTaskName_(name) {
   var map = {
-    'Reading Comprehension (WIAT)': 'Reading Comprehension Task'
+    'Reading Comprehension (RC)': 'Reading Comprehension Task'
   };
   return map[name] || name;
 }
@@ -1949,7 +1949,7 @@ function repairCorruptedSessionCells() {
  * - Inventory all sheets
  * - Consolidate old video logs into "Video Tracking"
  * - Hide/Archive deprecated or duplicate/empty sheets
- * - Keep WIAT/MRT/Spatial Navigation raw sheets (hidden)
+ * - Keep RC/MRT/Spatial Navigation raw sheets (hidden)
  **************/
 
 var HOUSEKEEPING_CONFIG = {
@@ -1957,12 +1957,12 @@ var HOUSEKEEPING_CONFIG = {
   mustKeep: [
     'Sessions','Task Progress','Session Events',
     'Video Tracking','Email Reminders',
-    'Scores Summary','ASLCT Scores','WIAT Scores',
+    'Scores Summary','ASLCT Scores','RC Scores',
     'Dashboard'
   ],
 
   // Sheets to hide (but keep) if they match this prefix/regex (raw task data)
-  taskRawRegex: /^(WIAT|MRT|Spatial\s*Navigation)/i,
+  taskRawRegex: /^(RC|MRT|Spatial\s*Navigation)/i,
 
   // Known legacy or noise sheets we can archive/hide (delete only if truly empty)
   deprecatedNames: [

--- a/index.html
+++ b/index.html
@@ -820,7 +820,7 @@ const CODE_REGEX = /^\d{6}$/; // six digits from Qualtrics code
 
     // ----- Tasks -----
     const TASKS = {
-  'WIAT': { name:'Reading Comprehension (WIAT)', description:'Read passages and answer questions', type:'embed', embedUrl:'https://melodyfschwenk.github.io/readingcomp/', canSkip:true, estMinutes:15, requirements:'None' },
+  'RC': { name:'Reading Comprehension Task', description:'Read passages and answer questions', type:'embed', embedUrl:'https://melodyfschwenk.github.io/readingcomp/', canSkip:true, estMinutes:15, requirements:'None' },
   'MRT': { name:'Mental Rotation Task', description:'Decide if two images are the same or not', type:'embed', embedUrl:'https://melodyfschwenk.github.io/mrt/', canSkip:true, estMinutes:6,  requirements:'Keyboard recommended' },
   'ASLCT': { name:'ASL Comprehension Test', description:'For ASL users only', url:'https://vl2portal.gallaudet.edu/assessment/', type:'external', canSkip:true, estMinutes:15, requirements:'ASL users; stable connection' },
   'VCN': { name:'Virtual Campus Navigation', description:'Virtual SILC Test of Navigation (SILCton)', url:'http://www.virtualsilcton.com/study/753798747', type:'external', canSkip:true, estMinutes:20, requirements:'Desktop/laptop; keyboard (WASD) & mouse' },
@@ -838,7 +838,6 @@ const CODE_REGEX = /^\d{6}$/; // six digits from Qualtrics code
     // Add this after TASKS definition
     function getStandardTaskName(taskCode) {
       const mapping = {
-        'WIAT': 'Reading Comprehension Task',
         'RC': 'Reading Comprehension Task',
         'MRT': 'Mental Rotation Task',
         'ASLCT': 'ASL Comprehension Test',
@@ -857,8 +856,8 @@ const CODE_REGEX = /^\d{6}$/; // six digits from Qualtrics code
     };
 
     // ----- Task sequencing -----
-    const DESKTOP_TASKS = ['WIAT', 'MRT', 'ASLCT', 'VCN', 'SN', 'ID'];
-    const MOBILE_TASKS = ['WIAT', 'MRT', 'ASLCT', 'SN', 'ID'];
+    const DESKTOP_TASKS = ['RC', 'MRT', 'ASLCT', 'VCN', 'SN', 'ID'];
+    const MOBILE_TASKS = ['RC', 'MRT', 'ASLCT', 'SN', 'ID'];
 
     function mulberry32(a) {
       return function() {


### PR DESCRIPTION
## Summary
- swap WIAT task code for RC in task list and sequencing
- update score tracking and housekeeping sheets to use RC instead of WIAT

## Testing
- `npm test` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68add8a8f4488326ae4abd532f6d2043