### PR TITLE
Send completion status to sheet

### DIFF
--- a/google-apps-script.gs
+++ b/google-apps-script.gs
@@ -1255,7 +1255,7 @@ function completeStudy(ss, data) {
   }
   setByHeader_(s, row, 'Total Time (min)', data.totalDuration || 0);
   setByHeader_(s, row, 'Tasks Completed', required.length + '/' + required.length);
-  setByHeader_(s, row, 'Status', 'Complete');
+  setByHeader_(s, row, 'Status', data.status || 'Complete');
 
   logSessionEvent(ss, {
     sessionCode: data.sessionCode,

--- a/index.html
+++ b/index.html
@@ -2676,6 +2676,7 @@ function updateUploadProgress(percent, message) {
       await sendToSheets({
         action: 'study_completed',
         sessionCode: state.sessionCode,
+        status: 'Complete',
         totalDuration: Math.round(state.totalTimeSpent / 60000),
         deviceType: state.isMobile ? 'mobile/tablet' : 'desktop',
         timestamp: new Date().toISOString()


### PR DESCRIPTION
## Summary
- Include explicit `status: 'Complete'` when final "I'm finished" button submits to Google Sheets
- Apps Script uses provided status when marking a study as complete

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68ade0a636b88326bad5ca0c9d6cc6d7