### PR TITLE
Add EEG interest checkbox with automated reminders

### DIFF
--- a/google-apps-script.gs
+++ b/google-apps-script.gs
@@ -48,7 +48,7 @@ function doPost(e) {
       'task_skipped', 'task_completed',
       'image_recorded', 'image_recorded_and_uploaded', 'image_recorded_no_upload',
       'video_recorded',
-      'calendly_opened', 'eeg_interest_clicked',
+      'calendly_opened', 'eeg_interest_clicked', 'eeg_interest_opt_in',
       'study_completed',
       'save_state',
       'get_session'
@@ -267,6 +267,7 @@ function doPost(e) {
         break;
 
       case 'eeg_interest_clicked':
+      case 'eeg_interest_opt_in':
         logEEGInterest(ss, data);
         break;
 

--- a/index.html
+++ b/index.html
@@ -388,9 +388,10 @@
       </div>
 
       <div class="button-group" style="margin-top: 20px;">
-        <button class="button optional" onclick="requestEEGReminder()">
-          📧 Email Me When Scheduling Opens
-        </button>
+        <label style="display: flex; align-items: center; gap: 8px;">
+          <input type="checkbox" id="eeg-interest-checkbox" onchange="eegInterestChanged(this)">
+          <span>📧 Email me when scheduling opens</span>
+        </label>
         <button class="button success" onclick="scheduleEEG()" style="font-size: 16px; padding: 14px 28px;">
           🗓️ Schedule My EEG Session
         </button>
@@ -2753,9 +2754,10 @@ function updateUploadProgress(percent, message) {
       if (f) f.src = f.src;
     }
 
-    function requestEEGReminder() {
+    function eegInterestChanged(el) {
+      if (!el.checked) return;
       sendToSheets({
-        action: 'eeg_interest_clicked',
+        action: 'eeg_interest_opt_in',
         sessionCode: state.sessionCode || 'none',
         participantID: state.participantID || 'none',
         email: state.email || '',
@@ -3034,7 +3036,7 @@ async function sendToSheets(payload) {
     window.submitASLCTIssue = submitASLCTIssue;
     window.markComplete = markComplete;
     window.scheduleEEG = scheduleEEG;
-window.requestEEGReminder = requestEEGReminder;
+window.eegInterestChanged = eegInterestChanged;
 window.markEEGScheduled = markEEGScheduled;
 window.showSkipDialog = showSkipDialog;
 window.skipTaskProceed = skipTaskProceed;


### PR DESCRIPTION
## Summary
- Add checkbox to EEG section for participants to request email when scheduling reopens
- Send opt-in event to Apps Script and expose new handler
- Update Apps Script whitelist and handler to log EEG interest

## Testing
- `node --check temp-check.js`
- `node --check server.js && echo "syntax ok"`


------
https://chatgpt.com/codex/tasks/task_e_68aeebaaaa2c83268775b202c6856c25