### PR TITLE
feat: track tab and window activity

### DIFF
--- a/google-apps-script.gs
+++ b/google-apps-script.gs
@@ -45,6 +45,7 @@ function doPost(e) {
       'consent_opened', 'consent_completed', 'consent_verified', 'consent_affirmed',
       'video_declined',
       'task_started', 'task_departed', 'task_returned', 'inactivity',
+      'tab_hidden', 'tab_visible', 'window_closed',
         'task_skipped', 'task_completed', 'skilled_task_completed',
       'image_recorded', 'image_recorded_and_uploaded', 'image_recorded_no_upload',
       'video_recorded',
@@ -201,6 +202,39 @@ function doPost(e) {
           logSessionEvent(ss, {
             sessionCode: data.sessionCode,
             eventType: 'Inactivity',
+            details: data.task,
+            timestamp: data.timestamp
+          });
+        });
+        break;
+
+      case 'tab_hidden':
+        withDocLock_(function () {
+          logSessionEvent(ss, {
+            sessionCode: data.sessionCode,
+            eventType: 'Tab Hidden',
+            details: data.task,
+            timestamp: data.timestamp
+          });
+        });
+        break;
+
+      case 'tab_visible':
+        withDocLock_(function () {
+          logSessionEvent(ss, {
+            sessionCode: data.sessionCode,
+            eventType: 'Tab Visible',
+            details: data.task,
+            timestamp: data.timestamp
+          });
+        });
+        break;
+
+      case 'window_closed':
+        withDocLock_(function () {
+          logSessionEvent(ss, {
+            sessionCode: data.sessionCode,
+            eventType: 'Window Closed',
             details: data.task,
             timestamp: data.timestamp
           });

--- a/index.html
+++ b/index.html
@@ -1065,7 +1065,19 @@ function showInactivityPrompt() {
 });
 
 document.addEventListener('visibilitychange', () => {
-  if (document.hidden) taskTimer.pause('visibility'); else taskTimer.resume();
+  const payload = {
+    sessionCode: state.sessionCode,
+    task: getStandardTaskName(state.sequence[state.currentTaskIndex] || ''),
+    deviceType: state.isMobile ? 'mobile/tablet' : 'desktop',
+    timestamp: new Date().toISOString()
+  };
+  if (document.hidden) {
+    taskTimer.pause('visibility');
+    sendToSheets({ action: 'tab_hidden', ...payload });
+  } else {
+    taskTimer.resume();
+    sendToSheets({ action: 'tab_visible', ...payload });
+  }
 });
 
 window.addEventListener('blur', () => {
@@ -1089,6 +1101,21 @@ window.addEventListener('focus', () => {
 
 window.addEventListener('message', e => {
   if (e.data === 'heartbeat') taskTimer.recordActivity();
+});
+
+window.addEventListener('beforeunload', () => {
+  if (!CONFIG.SHEETS_URL) return;
+  const body = JSON.stringify({
+    action: 'window_closed',
+    sessionCode: state.sessionCode,
+    task: getStandardTaskName(state.sequence[state.currentTaskIndex] || ''),
+    deviceType: state.isMobile ? 'mobile/tablet' : 'desktop',
+    timestamp: new Date().toISOString(),
+    userAgent: navigator.userAgent
+  });
+  if (navigator.sendBeacon) {
+    navigator.sendBeacon(CONFIG.SHEETS_URL, body);
+  }
 });
 
 // Handle Dropbox OAuth redirect


### PR DESCRIPTION
## Summary
- log when participants hide the tab, return, or close the window to better measure task durations
- record these events in the Google Apps Script backend

## Testing
- `npm test` *(fails: ENOENT: no package.json)*
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_68af07a601cc83268c101264ea92b3e5