### PR TITLE
Fix timer object syntax in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1029,7 +1029,7 @@ let taskTimer = {
     this.inactivityTime += now - this.lastTick;
   }
   this.lastTick = now;
-}
+  },
 
   recordActivity() {
     this.lastActivity = Date.now();
@@ -1099,9 +1099,9 @@ let taskTimer = {
     pauseCount: this.pauseCount,
     paused,
     inactive,
-    activity: elapsed > 0 ? (active / elapsed) * 100 : 0
+  activity: elapsed > 0 ? (active / elapsed) * 100 : 0
   };
-}
+};
  
 
 function showInactivityPrompt() {


### PR DESCRIPTION
## Summary
- correct missing comma after `taskTimer.tick` method
- properly terminate `taskTimer` object definition

## Testing
- `node server.js & sleep 1; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_68af2b59da8c83268bb0ce00a8b41a9e