### PR TITLE
Update estimated duration and payment guarantee

### DIFF
--- a/index.html
+++ b/index.html
@@ -307,7 +307,7 @@
   <div class="info-box time">
     <div class="icon">⏱️</div>
     <div>
-      <h4 style="margin-bottom: 8px; font-weight: 600;">About 45-60 minutes total</h4>
+      <h4 style="margin-bottom: 8px; font-weight: 600;">About 60-90 minutes total</h4>
       <p style="margin: 0; color: inherit;">You can pause anytime and return later. Your progress saves automatically after each task.</p>
     </div>
   </div>
@@ -385,7 +385,7 @@
           <ul style="margin: 8px 0 0 0; padding-left: 16px; color: inherit;">
             <li>Captures real-time brain responses to spatial tasks</li>
             <li>Helps us understand how deaf and hearing brains process space differently</li>
-            <li><strong>Compensation:</strong> $25 for the online portion and $25 for the EEG session (about $50 total), with additional pay if the EEG session runs longer than expected.</li>
+            <li><strong>Compensation:</strong> $25 for the online portion (you'll receive the full $25 even if it takes less than an hour) and $25 for the EEG session (about $50 total), with additional pay if the EEG session runs longer than expected.</li>
             <li>ASL or spoken English available</li>
           </ul>
         </div>

--- a/sn/index.html
+++ b/sn/index.html
@@ -166,7 +166,7 @@
         <div class="info-box">
             <h3>What You Receive</h3>
             <ul style="text-align: left; color: #555;">
-                <li>$25 per hour, pro-rated for partial time</li>
+                <li>$25 for the session (full amount even if you finish in under an hour)</li>
                 <li>A small bison plush toy as a thank you for completing all study tasks</li>
                 <li>Stickers</li>
             </ul>


### PR DESCRIPTION
## Summary
- Clarify study takes about 60–90 minutes in welcome screen
- Note participants receive the full $25 even if online portion finishes under an hour
- Adjust compensation note on Spatial Navigation task page to guarantee full amount

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af55105ee483269aad9b712124489c