### PR TITLE
Clarify consent code workflow and inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,6 +171,11 @@
     .consent-card .status-icon { font-size: 48px; margin-bottom: 15px; }
     .consent-card h4 { color: var(--text-primary); margin-bottom: 10px; }
     .consent-card p { color: var(--text-secondary); font-size: 14px; margin-bottom: 15px; }
+    .code-note { margin-top: 8px; font-size: 14px; color: var(--text-secondary); }
+    .code-note li { margin-left: 20px; list-style: disc; }
+    .code-entry { margin-top: 12px; background: #f0f9ff; border: 2px dashed var(--info); padding: 15px; border-radius: 8px; }
+    .code-entry input { width: 100%; padding: 12px; border: 2px solid var(--primary); border-radius: 8px; font-size: 16px; }
+    .status-indicator { display: block; margin-top: 6px; color: var(--text-secondary); }
     .optional-info summary { cursor: pointer; font-weight: 600; }
 
     /* Tasks list */
@@ -567,31 +572,41 @@
     If you already completed these in the Qualtrics screener, you can verify with a code (optional) or affirm completion below.
   </p>
 
+  <div class="card" id="consent-steps">
+    <h3 style="margin-bottom:8px;">Steps to complete the consent forms</h3>
+    <ol style="margin-left:20px; text-align:left;">
+      <li>Click <strong>1. Open Form in New Tab</strong>.</li>
+      <li>Fill out the form. A code will appear at the end.</li>
+      <li>Copy the code, then return to this page.</li>
+      <li>Click <strong>2. Enter Code from Form</strong>, paste the code, and press <strong>Verify code</strong>.</li>
+      <li>If you've already done the form, choose <strong>Skip Code Entry (already completed)</strong>.</li>
+    </ol>
+    <p class="code-note">You can switch between tabs without losing progress.</p>
+  </div>
+
   <div class="consent-grid">
     <!-- Consent 1 -->
     <div class="consent-card" id="consent1-card">
       <div class="status-icon">📄</div>
       <h4>Research Consent</h4>
       <p>General study participation consent (required)</p>
+      <ul class="code-note">
+        <li>The consent form will show a code at the end.</li>
+        <li>Copy that code and paste it here.</li>
+        <li>You can switch between tabs to copy/paste.</li>
+      </ul>
       <div class="button-group" style="justify-content:center;">
-        <button class="button optional" onclick="openConsent('CONSENT1')">Open Form</button>
-        <!-- changed copy -->
-        <button class="button outline" onclick="markConsentDone('consent1')">✅ I completed this form</button>
+        <button class="button optional" onclick="openConsent('CONSENT1')">1. Open Form in New Tab</button>
+        <button class="button friendly" onclick="toggleCodeEntry('consent1')">2. Enter Code from Form</button>
+        <button class="button outline" onclick="markConsentDone('consent1')">Skip Code Entry (already completed)</button>
       </div>
-
-      <!-- optional code verify -->
-      <details class="optional-info" style="margin-top:12px; text-align:left;">
-        <summary>Have a confirmation code?</summary>
-        <div class="card" style="margin-top:12px; text-align:left;">
-          <label for="consent1-code" style="display:block; font-weight:600; margin-bottom:6px;">Confirmation code (optional)</label>
-          <input id="consent1-code" type="text" placeholder="Paste code from Qualtrics (e.g., last 6 of Response ID)"
-                 style="width:100%; padding:10px; border:2px solid var(--gray-300); border-radius:8px;">
-          <div class="button-group" style="justify-content:flex-start; margin-top:10px;">
-            <button class="button secondary" onclick="verifyConsentCode('consent1')">Verify code</button>
-          </div>
-          <small id="consent1-verify-note" style="display:block; color:var(--text-secondary); margin-top:6px;"></small>
+      <div id="consent1-code-container" class="code-entry" style="display:none;">
+        <input id="consent1-code" type="text" placeholder="Paste the code from the consent form here">
+        <div class="button-group" style="justify-content:flex-start; margin-top:10px;">
+          <button class="button secondary" onclick="verifyConsentCode('consent1')">Verify code</button>
         </div>
-      </details>
+        <small id="consent1-verify-note" class="status-indicator">🔄 Waiting for consent form code...</small>
+      </div>
     </div>
 
     <!-- Consent 2 -->
@@ -599,26 +614,24 @@
       <div class="status-icon">🎥</div>
       <h4>Video Consent</h4>
       <p>For the image description recording task (optional)</p>
+      <ul class="code-note">
+        <li>The consent form will show a code at the end.</li>
+        <li>Copy that code and paste it here.</li>
+        <li>You can switch between tabs to copy/paste.</li>
+      </ul>
       <div class="button-group" style="justify-content:center;">
-        <button class="button optional" onclick="openConsent('CONSENT2')">Open Form</button>
-        <!-- changed copy -->
-        <button class="button outline" onclick="markConsentDone('consent2')">✅ I completed this form</button>
+        <button class="button optional" onclick="openConsent('CONSENT2')">1. Open Form in New Tab</button>
+        <button class="button friendly" onclick="toggleCodeEntry('consent2')">2. Enter Code from Form</button>
+        <button class="button outline" onclick="markConsentDone('consent2')">Skip Code Entry (already completed)</button>
         <button class="button secondary" onclick="declineVideo()">Decline Video</button>
       </div>
-
-      <!-- optional code verify -->
-      <details class="optional-info" style="margin-top:12px; text-align:left;">
-        <summary>Have a confirmation code?</summary>
-        <div class="card" style="margin-top:12px; text-align:left;">
-          <label for="consent2-code" style="display:block; font-weight:600; margin-bottom:6px;">Confirmation code (optional)</label>
-          <input id="consent2-code" type="text" placeholder="Paste code from Qualtrics"
-                 style="width:100%; padding:10px; border:2px solid var(--gray-300); border-radius:8px;">
-          <div class="button-group" style="justify-content:flex-start; margin-top:10px;">
-            <button class="button secondary" onclick="verifyConsentCode('consent2')">Verify code</button>
-          </div>
-          <small id="consent2-verify-note" style="display:block; color:var(--text-secondary); margin-top:6px;"></small>
+      <div id="consent2-code-container" class="code-entry" style="display:none;">
+        <input id="consent2-code" type="text" placeholder="Paste the code from the consent form here">
+        <div class="button-group" style="justify-content:flex-start; margin-top:10px;">
+          <button class="button secondary" onclick="verifyConsentCode('consent2')">Verify code</button>
         </div>
-      </details>
+        <small id="consent2-verify-note" class="status-indicator">🔄 Waiting for consent form code...</small>
+      </div>
     </div>
   </div>
 
@@ -1489,13 +1502,24 @@ function checkSavedSession() {
       showScreen('consent-screen');
       updateConsentDisplay();
     }
-    function openConsent(type) {
-      const consent = CONSENTS[type];
-      if (consent) {
-        window.open(consent.url, '_blank', 'noopener');
-        sendToSheets({ action: 'consent_opened', sessionCode: state.sessionCode, type, timestamp: new Date().toISOString() });
-      }
-    }
+function openConsent(type) {
+  const consent = CONSENTS[type];
+  if (consent) {
+    window.open(consent.url, '_blank', 'noopener');
+    sendToSheets({ action: 'consent_opened', sessionCode: state.sessionCode, type, timestamp: new Date().toISOString() });
+  }
+}
+function toggleCodeEntry(type) {
+  const container = document.getElementById(`${type}-code-container`);
+  const note = document.getElementById(`${type}-verify-note`);
+  if (!container) return;
+  const show = container.style.display === 'none' || container.style.display === '';
+  container.style.display = show ? 'block' : 'none';
+  if (show && note) {
+    note.textContent = '🔄 Waiting for consent form code...';
+    note.style.color = 'var(--text-secondary)';
+  }
+}
    function markConsentDone(type) {
   // Safety interlock: explicit warning + typed phrase
   const niceName = (type === 'consent1') ? 'Research Consent' : 'Video Consent';
@@ -1557,7 +1581,7 @@ function verifyConsentCode(type) {
   updateConsentDisplay();
 
   if (noteEl) {
-    noteEl.textContent = '✅ Verified via code';
+    noteEl.textContent = '✅ Code verified!';
     noteEl.style.color = '#1b5e20';
   }
 
@@ -1657,7 +1681,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const note = document.getElementById('consent1-verify-note');
     if (state.consentVerify.consent1.verified) {
-      if (note) { note.textContent = `Verified via ${state.consentVerify.consent1.method} ${state.consentVerify.consent1.note ? '('+state.consentVerify.consent1.note+')' : ''}`; note.style.color = '#1b5e20'; }
+      if (note) { note.textContent = '✅ Code verified!'; note.style.color = '#1b5e20'; }
     } else {
       if (note) { note.textContent = 'Affirmed without code'; note.style.color = '#856404'; }
     }
@@ -1674,7 +1698,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const note = document.getElementById('consent2-verify-note');
     if (state.consentVerify.consent2.verified) {
-      if (note) { note.textContent = `Verified via ${state.consentVerify.consent2.method} ${state.consentVerify.consent2.note ? '('+state.consentVerify.consent2.note+')' : ''}`; note.style.color = '#1b5e20'; }
+      if (note) { note.textContent = '✅ Code verified!'; note.style.color = '#1b5e20'; }
     } else if (note) {
       note.textContent = state.consentStatus.consent2 ? 'Affirmed without code' : '';
       note.style.color = '#856404';


### PR DESCRIPTION
## Summary
- Add step-by-step consent instructions and reminders to copy verification codes
- Simplify consent flow with "Open Form" and "Enter Code" buttons and visible code entry fields
- Show status messages for pending and verified codes with new toggle logic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68afb2949f748326bf9acf1b52dfbc9b