### PR TITLE
Log client input events

### DIFF
--- a/google-apps-script.gs
+++ b/google-apps-script.gs
@@ -59,7 +59,8 @@ function doPost(e) {
       'save_state',
       'get_session',
       'heartbeat',
-      'external_task_stuck'
+      'external_task_stuck',
+      'mousemove', 'mousedown', 'keydown', 'touchstart'
     ]);
     if (!allowed.has(data.action)) {
       return createCorsOutput({ success: false, error: 'Unknown action' });
@@ -273,6 +274,30 @@ function doPost(e) {
             sessionCode: data.sessionCode,
             eventType: 'Window Closed',
             details: data.task,
+            timestamp: data.timestamp
+          });
+        });
+        break;
+
+      case 'mousemove':
+      case 'mousedown':
+      case 'touchstart':
+      case 'keydown':
+        withDocLock_(function () {
+          var details = {};
+          if (typeof data.x === 'number') details.x = data.x;
+          if (typeof data.y === 'number') details.y = data.y;
+          if (data.key) details.key = data.key;
+          var typeMap = {
+            mousemove: 'Mouse Move',
+            mousedown: 'Mouse Down',
+            touchstart: 'Touch Start',
+            keydown: 'Key Down'
+          };
+          logSessionEvent(ss, {
+            sessionCode: data.sessionCode,
+            eventType: typeMap[data.action] || data.action,
+            details: Object.keys(details).length ? JSON.stringify(details) : '',
             timestamp: data.timestamp
           });
         });

--- a/index.html
+++ b/index.html
@@ -1237,11 +1237,30 @@ function logSessionTime(stage, summary = sessionTimer.getSummary()) {
 }
 
 ['mousemove','mousedown','keydown','touchstart'].forEach(ev => {
-  document.addEventListener(ev, () => {
+  document.addEventListener(ev, (e) => {
     taskTimer.recordActivity();
     sessionTimer.recordActivity();
+    sendInputEvent(ev, e);
   }, { passive: true });
 });
+
+function sendInputEvent(type, e) {
+  if (!state.sessionCode) return;
+  const payload = {
+    action: type,
+    sessionCode: state.sessionCode,
+    timestamp: new Date().toISOString()
+  };
+  if (type === 'mousemove' || type === 'mousedown' || type === 'touchstart') {
+    const point = e.touches && e.touches[0] ? e.touches[0] : e;
+    payload.x = point.clientX;
+    payload.y = point.clientY;
+  }
+  if (type === 'keydown') {
+    payload.key = e.key;
+  }
+  sendToSheets(payload);
+}
 
 document.addEventListener('visibilitychange', () => {
   const payload = {


### PR DESCRIPTION
## Summary
- Allow Apps Script backend to accept raw input actions (mouse, key, touch) and record coordinates or keys in Session Events
- Front-end now posts mouse, touch and keyboard events so all browsers report fine-grained activity

## Testing
- `cp google-apps-script.gs tmp.js && node --check tmp.js && rm tmp.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b05d1b87548326b4803f2bf3e64944