### PR TITLE
Handle browsers without MediaRecorder by guiding manual uploads

### DIFF
--- a/index.html
+++ b/index.html
@@ -2263,6 +2263,12 @@ if (instructionBox) {
       if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
         throw { code: 'NO_MEDIADEVICES', message: 'This browser does not support in-page recording.' };
       }
+      if (!window.MediaRecorder) {
+        throw {
+          code: 'NO_MEDIARECORDER',
+          message: 'This browser does not support in-page recording.'
+        };
+      }
       let cam = 'unknown', mic = 'unknown';
       try {
         const camPerm = await navigator.permissions.query({ name: 'camera' });
@@ -2432,7 +2438,7 @@ if (instructionBox) {
           }
 
           if (!window.MediaRecorder) {
-            showRecordingError(`<strong>Recording not supported in this browser</strong><p style="margin-top: 6px;">Please use Chrome, Edge, or Firefox, or upload a recording below.</p>`);
+            showRecordingError(`<strong>Recording not supported in this browser</strong><p style="margin-top: 6px;">Please record using your device's camera or voice recorder, then upload the file below.</p>`);
             return;
           }
 
@@ -2604,6 +2610,11 @@ if (instructionBox) {
         'NotReadableError': {
           title: 'Device in use',
           message: 'Camera or microphone is being used by another application. Please close other apps and try again.',
+          showUpload: true
+        },
+        'NO_MEDIARECORDER': {
+          title: 'Recording not supported',
+          message: 'This browser cannot record directly. Use your device\'s camera or voice recorder and upload the file below.',
           showUpload: true
         }
       };


### PR DESCRIPTION
## Summary
- Detect missing `MediaRecorder` before starting capture and stop the recording flow
- Show a clear message guiding users to record with their device and upload through the fallback
- Include an error handler entry for unsupported recording to surface the same guidance

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b061e6d1248326b00e11ac5737c290