### PR TITLE
feat: add polyfills and Babel for legacy browser support

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Spatial Cognition & Sign Language Research Study</title>
   <script src="https://unpkg.com/dropbox/dist/Dropbox-sdk.min.js"></script>
+  <!-- Polyfills for older browsers -->
+  <script src="https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/url-search-params-polyfill@8.1.0/index.js"></script>
+  <!-- Babel standalone for optional chaining transpilation -->
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   <style>
     * { margin:0; padding:0; box-sizing:border-box; }
     :root {
@@ -893,7 +898,7 @@
   </div>
 </div>
 
-  <script>
+  <script type="text/babel" data-presets="env">
     // ----- Configuration -----
     const CONFIG = {
   SHEETS_URL: 'https://script.google.com/macros/s/AKfycbxT4jpPNG6hTDbmpeo6utlOwHLPTrxBna_YjcG0yLNI9pO5hcI7yIJcTwgesvocSYSG4A/exec',


### PR DESCRIPTION
## Summary
- add Promise and URLSearchParams polyfills via CDN
- use Babel standalone to transpile optional chaining at runtime for older browsers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b06324b51c8326b08565bcb01151d4