### PR TITLE
Expose CORS headers for Google Apps Script responses

### DIFF
--- a/google-apps-script.gs
+++ b/google-apps-script.gs
@@ -419,6 +419,10 @@ function doGet(e) {
 function createCorsOutput(data) {
   var output = ContentService.createTextOutput(JSON.stringify(data));
   output.setMimeType(ContentService.MimeType.JSON);
+  // Explicit CORS headers so browser requests from the front-end succeed
+  output.setHeader('Access-Control-Allow-Origin', '*');
+  output.setHeader('Access-Control-Allow-Methods', 'POST, GET, OPTIONS');
+  output.setHeader('Access-Control-Allow-Headers', 'Content-Type');
   return output;
 }
 


### PR DESCRIPTION
## Summary
- Ensure the `createCorsOutput` helper returns proper CORS headers so browser clients can post data to the Apps Script backend.

## Testing
- `cp google-apps-script.gs temp.js && node --check temp.js`
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_68b086f228a883268b32d036b840495c