### PR TITLE
fix: ensure image shows in non-secure recording

### DIFF
--- a/index.html
+++ b/index.html
@@ -2207,14 +2207,16 @@ function openExternalTask(taskCode) {
         updateRecordingImage();
       }
       // NEW: if page not secure, skip recorder UI and show upload UI
-if (!window.isSecureContext) {
-  document.getElementById('recording-consent-check').style.display = 'none';
-  document.getElementById('recording-content').style.display = 'block';
-  document.getElementById('video-upload-fallback').style.display = 'block';
-  const status = document.getElementById('recording-status');
-  status.textContent = 'Recording disabled (requires https). Please use the upload option below.';
-  status.className = 'recording-status warning';
-}
+      if (!window.isSecureContext) {
+        document.getElementById('recording-consent-check').style.display = 'none';
+        document.getElementById('recording-content').style.display = 'block';
+        document.getElementById('video-upload-fallback').style.display = 'block';
+        // Ensure the current image is shown even without recording
+        updateRecordingImage();
+        const status = document.getElementById('recording-status');
+        status.textContent = 'Recording disabled (requires https). Please use the upload option below.';
+        status.className = 'recording-status warning';
+      }
 
       showScreen('recording-screen');
     }


### PR DESCRIPTION
## Summary
- Load the first image when the image description task runs in a non-secure context

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b08a0711e48326ba343f4ca047e9fb