### PR TITLE
Fix recording instructions insertion to prevent task freeze

### DIFF
--- a/main.js
+++ b/main.js
@@ -1436,9 +1436,9 @@ function updateRecordingImage() {
 
   // Insert before recording controls
   var recordingContent = document.getElementById('recording-content');
-  var recordingControls = document.querySelector('.recording-controls');
-  if (recordingContent && recordingControls && !document.getElementById('recording-size-warning')) {
-    recordingContent.insertBefore(recordingInstructions, recordingControls);
+  var recordingControls = recordingContent ? recordingContent.querySelector('.recording-controls') : null;
+  if (recordingControls && recordingControls.parentNode && !document.getElementById('recording-size-warning')) {
+    recordingControls.parentNode.insertBefore(recordingInstructions, recordingControls);
   }
   var requiredTextRec = state.consentStatus.videoDeclined ? 'This task is OPTIONAL for you (video consent declined).' : 'This task is required for study completion.';
   var etaRec = TASKS['ID'] && TASKS['ID'].estMinutes ? "".concat(TASKS['ID'].estMinutes, " minutes") : 'a few minutes';

--- a/src/main.js
+++ b/src/main.js
@@ -1383,9 +1383,9 @@ function openExternalTask(taskCode) {
 
       // Insert before recording controls
       const recordingContent = document.getElementById('recording-content');
-      const recordingControls = document.querySelector('.recording-controls');
-      if (recordingContent && recordingControls && !document.getElementById('recording-size-warning')) {
-        recordingContent.insertBefore(recordingInstructions, recordingControls);
+      const recordingControls = recordingContent ? recordingContent.querySelector('.recording-controls') : null;
+      if (recordingControls && recordingControls.parentNode && !document.getElementById('recording-size-warning')) {
+        recordingControls.parentNode.insertBefore(recordingInstructions, recordingControls);
       }
 
       const requiredTextRec = (state.consentStatus.videoDeclined)


### PR DESCRIPTION
## Summary
- Insert recording guidelines before recording controls using the controls' parent node to avoid DOM errors

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b08d5a083c8326884f0ba599189c2a