### PR TITLE
Fix CORS failures when logging to Google Sheets

### DIFF
--- a/main.js
+++ b/main.js
@@ -3456,10 +3456,11 @@ function _sendToSheets() {
           _context17.n = 3;
           return fetch(CONFIG.SHEETS_URL, {
             method: 'POST',
+            mode: 'no-cors',
             headers: {
-              'Content-Type': 'text/plain;charset=utf-8'
+              'Content-Type': 'text/plain'
             },
-            // simple request, no preflight
+            // simple request, bypasses CORS preflight
             body: JSON.stringify(body)
           });
         case 3:

--- a/src/main.js
+++ b/src/main.js
@@ -2984,7 +2984,8 @@ async function sendToSheets(payload) {
   try {
     await fetch(CONFIG.SHEETS_URL, {
       method: 'POST',
-      headers: { 'Content-Type': 'text/plain;charset=utf-8' }, // simple request, no preflight
+      mode: 'no-cors',
+      headers: { 'Content-Type': 'text/plain' }, // simple request, bypasses CORS preflight
       body: JSON.stringify(body)
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
- send log requests using `no-cors` fetch to bypass missing CORS headers from Google Apps Script

## Testing
- `npm run build`
- `npm test` *(fails: Missing script: "test"* )

------
https://chatgpt.com/codex/tasks/task_e_68b094af881c832687ef6b3cb4da9792