### PR TITLE
Ensure video preview shows during image descriptions

### DIFF
--- a/main.js
+++ b/main.js
@@ -1358,6 +1358,7 @@ function _startPreview() {
           }
           preview.srcObject = state.recording.stream;
           preview.style.display = 'block';
+          preview.play()["catch"](function () {});
           return _context4.a(2);
         case 1:
           _context4.p = 1;
@@ -1387,6 +1388,7 @@ function _startPreview() {
           state.recording.isVideoMode = true;
           preview.srcObject = stream;
           preview.style.display = 'block';
+          preview.play()["catch"](function () {});
           _context4.n = 6;
           break;
         case 5:
@@ -1695,6 +1697,7 @@ function _toggleRecording() {
           if (isVideoMode) {
             preview.srcObject = stream;
             preview.style.display = 'block';
+            preview.play()["catch"](function () {});
           } else {
             preview.style.display = 'none';
             status.textContent = '🎤 Audio ready to record';

--- a/src/main.js
+++ b/src/main.js
@@ -1298,6 +1298,7 @@ function openExternalTask(taskCode) {
       if (state.recording.stream) {
         preview.srcObject = state.recording.stream;
         preview.style.display = 'block';
+        preview.play().catch(() => {});
         return;
       }
       try {
@@ -1317,6 +1318,7 @@ function openExternalTask(taskCode) {
         state.recording.isVideoMode = true;
         preview.srcObject = stream;
         preview.style.display = 'block';
+        preview.play().catch(() => {});
       } catch (e) {
         console.error('Preview failed:', e);
       }
@@ -1594,6 +1596,7 @@ function bindRecordingSkips() {
           if (isVideoMode) {
             preview.srcObject = stream;
             preview.style.display = 'block';
+            preview.play().catch(() => {});
           } else {
             preview.style.display = 'none';
             status.textContent = '🎤 Audio ready to record';


### PR DESCRIPTION
## Summary
- Guarantee the camera stream plays in the preview element for the image description task
- Add explicit `preview.play()` calls when initializing or starting recordings

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b09afca62083268d978dd78f021070