### PR TITLE
Harden server error handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,4 @@
 - Run `npm run build` after modifying source files in `src/`.
 - Commit both the source files and the generated `main.js` artifact.
 - Use 2 spaces for indentation.
+- Check server logs for startup/runtime errors and ensure request and server errors are properly handled.

--- a/server.js
+++ b/server.js
@@ -17,14 +17,18 @@ const server = http.createServer((req, res) => {
     res.writeHead(204, {
       'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Methods': 'POST, OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type'
+      'Access-Control-Allow-Headers': 'Content-Type',
+      'Content-Type': 'application/json'
     });
     return res.end();
   }
 
   if (req.method !== 'POST') {
-    res.writeHead(405, { 'Access-Control-Allow-Origin': '*' });
-    return res.end();
+    res.writeHead(405, {
+      'Access-Control-Allow-Origin': '*',
+      'Content-Type': 'application/json'
+    });
+    return res.end(JSON.stringify({ success: false, error: 'Method not allowed' }));
   }
 
   let body = '';
@@ -57,10 +61,23 @@ const server = http.createServer((req, res) => {
     });
     res.end(JSON.stringify({ success: true }));
   });
+
+  req.on('error', err => {
+    console.error('Request error:', err);
+    res.writeHead(500, {
+      'Access-Control-Allow-Origin': '*',
+      'Content-Type': 'application/json'
+    });
+    res.end(JSON.stringify({ success: false, error: 'Request stream error' }));
+  });
 });
 
 const PORT = process.env.PORT || 3000;
 server.listen(PORT, () => {
   console.log(`Server listening on port ${PORT}`);
+});
+
+server.on('error', err => {
+  console.error('Server error:', err);
 });
 


### PR DESCRIPTION
## Summary
- capture request stream errors and respond with JSON
- log server-level errors on the http server
- send `Content-Type: application/json` for every request/response path
- document error handling expectations in AGENTS instructions

## Testing
- `npm run build`
- `node server.js >/tmp/server.log & pid=$!; sleep 1; kill $pid; sleep 1; cat /tmp/server.log`

------
https://chatgpt.com/codex/tasks/task_e_68b09fce8fc48326a4503947ed5f4c20