### PR TITLE
Add startup config validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,4 @@
 - Commit both the source files and the generated `main.js` artifact.
 - Use 2 spaces for indentation.
 - Check server logs for startup/runtime errors and ensure request and server errors are properly handled.
+- Guard against missing critical configuration values at server startup, logging warnings on the backend so participants don't see them.

--- a/server.js
+++ b/server.js
@@ -5,6 +5,17 @@
 
 const http = require('http');
 
+const REQUIRED_CONFIG = ['SHEETS_URL', 'CLOUDINARY_CLOUD_NAME', 'CLOUDINARY_UPLOAD_PRESET'];
+
+function validateConfig() {
+  const missing = REQUIRED_CONFIG.filter(key => !process.env[key]);
+  if (missing.length) {
+    console.warn(`Missing configuration values: ${missing.join(', ')}`);
+  }
+}
+
+validateConfig();
+
 function validatePayload(data) {
   return data &&
     typeof data.sessionCode === 'string' && data.sessionCode.trim() !== '' &&

--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,7 @@
   CLOUDINARY_UPLOAD_PRESET: 'study_videos', 
       CLOUDINARY_FOLDER: 'spatial-cognition-videos',
 };
+
 const CODE_REGEX = /^\d{6}$/; // six digits from Qualtrics code
 
 document.querySelectorAll('.support-email').forEach(el => {


### PR DESCRIPTION
## Summary
- validate critical CONFIG values on the backend and warn if missing
- document backend-only config validation in AGENTS instructions

## Testing
- `npm run build`
- `node server.js`


------
https://chatgpt.com/codex/tasks/task_e_68b0a347d46483268b8c3071a695419d