### PR TITLE
Add start script and update agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,7 @@
 - Use 2 spaces for indentation.
 - Check server logs for startup/runtime errors and ensure request and server errors are properly handled.
 - Guard against missing critical configuration values at server startup, logging warnings on the backend so participants don't see them.
+- Use `npm start` to launch the Node server and monitor logs for warnings or errors.
+
+## TODO
+- [ ] Split `src/main.js` into smaller modules to simplify maintenance.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "build": "babel src --out-file main.js --presets @babel/preset-env"
+    "build": "babel src --out-file main.js --presets @babel/preset-env",
+    "start": "node server.js"
   },
   "devDependencies": {
     "@babel/cli": "^7.24.0",


### PR DESCRIPTION
## Summary
- Simplify server startup by adding an `npm start` script.
- Document the new start script and future refactor task in AGENTS instructions.

## Testing
- `npm run build`
- `npm start` (logs warnings for missing config and server listening)

------
https://chatgpt.com/codex/tasks/task_e_68b0b112f6688326b36e5ce697ab451b