### PR TITLE
Add npm test script and update contributor guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,7 @@
 
 - Run `npm run build` after modifying source files in `src/`.
 - Commit both the source files and the generated `main.js` artifact.
+- Run `npm test` before committing to check for syntax errors.
 - Use 2 spaces for indentation.
 - Check server logs for startup/runtime errors and ensure request and server errors are properly handled.
 - Guard against missing critical configuration values at server startup, logging warnings on the backend so participants don't see them.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "build": "babel src --out-file main.js --presets @babel/preset-env",
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "node --check src/main.js && node --check server.js"
   },
   "devDependencies": {
     "@babel/cli": "^7.24.0",


### PR DESCRIPTION
## Summary
- add npm `test` script to check syntax for `src/main.js` and `server.js`
- remind contributors to run `npm test` before committing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0cff66df083269ec44a5fcc257e25