### PR TITLE
Convert video upload file size to KB

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 - Check server logs for startup/runtime errors and ensure request and server errors are properly handled.
 - Guard against missing critical configuration values at server startup, logging warnings on the backend so participants don't see them.
 - Use `npm start` to launch the Node server and monitor logs for warnings or errors.
+- Upload metrics expect file sizes in kilobytes.
 
 ## TODO
 - [ ] Split `src/main.js` into smaller modules to simplify maintenance.

--- a/google-apps-script.gs
+++ b/google-apps-script.gs
@@ -2328,6 +2328,9 @@ function logVideoUpload(data) {
     formatHeaders(sheet, 15);
   }
 
+  // Convert file size to KB for logging
+  var fileSizeKB = data.fileSize ? data.fileSize / 1024 : 0;
+
   // Prepare row data
   var rowData = [
     new Date(),
@@ -2336,7 +2339,7 @@ function logVideoUpload(data) {
     data.filename || '',
     data.fileId || '',
     data.fileUrl || '',
-    data.fileSize || 0,
+    fileSizeKB,
     data.uploadTime || new Date().toISOString(),
     data.uploadMethod || 'unknown',
     data.externalService || determineServiceFromMethod(data.uploadMethod),
@@ -2348,8 +2351,9 @@ function logVideoUpload(data) {
   ];
 
   sheet.appendRow(rowData);
-  
-  // Log success metrics
+
+  // Log success metrics using KB
+  data.fileSize = fileSizeKB;
   logUploadMetrics(data);
 }
 


### PR DESCRIPTION
## Summary
- Convert uploaded video file sizes from bytes to kilobytes before logging and metrics.
- Clarify in AGENTS instructions that upload metrics expect file sizes in kilobytes.

## Testing
- `node - <<'NODE'` (apps script unit conversion check)
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68b0d00ea5c083268311e2ef4e3a0ef2