### PR TITLE
Add centralized Apps Script error handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 - Guard against missing critical configuration values at server startup, logging warnings on the backend so participants don't see them.
 - Use `npm start` to launch the Node server and monitor logs for warnings or errors.
 - Upload metrics expect file sizes in kilobytes.
+- Centralize Apps Script error handling with `handleError`, wrapping spreadsheet operations in try/catch.
 
 ## TODO
 - [ ] Split `src/main.js` into smaller modules to simplify maintenance.


### PR DESCRIPTION
## Summary
- add `handleError` utility for logging errors and optional UI alerts
- wrap video logging spreadsheet writes with try/catch and use `handleError`
- document the error-handling approach and update AGENTS instructions

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b0d58adf1083268a7aad0ef77609c1