### PR TITLE
Add setup README and link in AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,6 @@
 # AGENTS instructions
 
+- Refer to `README.md` for installation, build/start commands, and environment variable setup.
 - Run `npm run build` after modifying source files in `src/`.
 - Run `npm run lint` before committing.
 - Commit both the source files and the generated `main.js` artifact.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# Dissertation Study
+
+This project collects video upload data for a dissertation study.
+
+## Installation
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+## Build
+
+Compile source files in `src/` to `main.js`:
+
+```bash
+npm run build
+```
+
+Run this after any changes to files in `src/`.
+
+## Start
+
+Start the Node server:
+
+```bash
+npm start
+```
+
+Check the console for warnings or errors during startup.
+
+## Environment variables
+
+Create a `.env` file or export these variables before running the server:
+
+```
+SHEETS_URL=<Google Sheets endpoint>
+CLOUDINARY_CLOUD_NAME=<Cloudinary cloud name>
+CLOUDINARY_UPLOAD_PRESET=<Cloudinary upload preset>
+PORT=<optional port, defaults to 3000>
+```
+
+Do not commit the `.env` file to version control.


### PR DESCRIPTION
## Summary
- document installation, build, startup, and required environment variables
- point contributors to README from AGENTS instructions

## Testing
- `npm run build`
- `npm start` (with placeholder env vars)
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d7cadc188326a2863ef919860d3a