### PR TITLE
Specify Node 18 requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,7 @@
 
 - Run `npm run build` after modifying source files in `src/`.
 - Run `npm run lint` before committing.
+- Use Node.js >= 18.
 - Commit both the source files and the generated `main.js` artifact.
 - Use 2 spaces for indentation.
 - Check server logs for startup/runtime errors and ensure request and server errors are properly handled.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# Dissertation Study
+
+This project requires Node.js version 18 or higher.
+

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
   },
   "dependencies": {
     "dotenv": "^17.2.1"
+  },
+  "engines": {
+    "node": ">=18"
   }
 }


### PR DESCRIPTION
## Summary
- require Node.js 18+ via package.json engines field
- document Node.js 18+ requirement in AGENTS.md and README

## Testing
- `npm run lint` *(fails: ✖ 1275 problems (1275 errors, 0 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68b0d7e26810832683461e769b9db24e