### PR TITLE
Add editor configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 - Run `npm run build` after modifying source files in `src/`.
 - Run `npm run lint` before committing.
 - Commit both the source files and the generated `main.js` artifact.
-- Use 2 spaces for indentation.
+- Use 2 spaces for indentation; see `.editorconfig` (UTF-8 encoding) for editor settings.
 - Check server logs for startup/runtime errors and ensure request and server errors are properly handled.
 - Guard against missing critical configuration values at server startup, logging warnings on the backend so participants don't see them.
 - Use `npm start` to launch the Node server and monitor logs for warnings or errors.


### PR DESCRIPTION
## Summary
- add repository-wide `.editorconfig` for 2-space indentation and UTF-8 encoding
- document editor configuration usage in `AGENTS.md`

## Testing
- `npm run lint` *(fails: ESLint reported existing indentation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d7e7afa48326ab4ba0ef3f3bca39