### PR TITLE
feat: warn on unsaved work before closing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 - Run `npm run lint` before committing.
 - Commit both the source files and the generated `main.js` artifact.
 - Use 2 spaces for indentation.
+- Retain the `beforeunload` safeguard that warns about unsaved recordings or incomplete tasks when changing page flow.
 - Check server logs for startup/runtime errors and ensure request and server errors are properly handled.
 - Guard against missing critical configuration values at server startup, logging warnings on the backend so participants don't see them.
 - Use `npm start` to launch the Node server and monitor logs for warnings or errors.


### PR DESCRIPTION
## Summary
- prompt participants before closing tab if recordings or tasks are incomplete
- capture unsaved/incomplete state in beacon sent on unload
- document beforeunload safeguard in AGENTS.md to preserve warning

## Testing
- `npm run lint` (fails: ESLint couldn't find a configuration file)
- `npm run build`
- `npm start` (server warns about missing config and listens on port 3000)

------
https://chatgpt.com/codex/tasks/task_e_68b0d8ba1ecc8326927a54b2b133e750