### PR TITLE
Exit on missing server config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 - Use 2 spaces for indentation.
 - Check server logs for startup/runtime errors and ensure request and server errors are properly handled.
 - Guard against missing critical configuration values at server startup, logging warnings on the backend so participants don't see them.
+- The server refuses to start without `SHEETS_URL`, `CLOUDINARY_CLOUD_NAME`, and `CLOUDINARY_UPLOAD_PRESET`.
 - Use `npm start` to launch the Node server and monitor logs for warnings or errors.
 - Do not commit `.env`, `*.log`, or `.DS_Store` files; these are ignored.
 - Upload metrics expect file sizes in kilobytes.

--- a/server.js
+++ b/server.js
@@ -12,6 +12,7 @@ function validateConfig() {
   const missing = REQUIRED_CONFIG.filter(key => !process.env[key]);
   if (missing.length) {
     console.warn(`Missing configuration values: ${missing.join(', ')}`);
+    process.exit(1);
   }
 }
 


### PR DESCRIPTION
## Summary
- Fail fast if required env vars SHEETS_URL, CLOUDINARY_CLOUD_NAME, or CLOUDINARY_UPLOAD_PRESET are missing
- Document that the server refuses to start without these env vars

## Testing
- `npm run lint` *(fails: 1275 problems)*
- `npm start` *(fails: Missing configuration values: SHEETS_URL, CLOUDINARY_CLOUD_NAME, CLOUDINARY_UPLOAD_PRESET)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d8a48ec88326a9f7e71300829354