### PR TITLE
Skip repeat video consent for image description task

### DIFF
--- a/main.js
+++ b/main.js
@@ -1307,11 +1307,25 @@ function openExternalTask(taskCode) {
 }
 
 // ----- Recording task -----
+function hasVideoConsent() {
+  if (state.consentStatus.consent2 || state.consentStatus.videoDeclined) return true;
+  try {
+    var recent = localStorage.getItem('recent_session');
+    if (!recent) return false;
+    var saved = localStorage.getItem("study_".concat(recent));
+    if (!saved) return false;
+    var data = JSON.parse(saved);
+    return !!(data.consentStatus && (data.consentStatus.consent2 || data.consentStatus.videoDeclined));
+  } catch (e) {
+    console.warn('Could not check saved consent', e);
+    return false;
+  }
+}
 function showRecordingTask() {
   state.recording.currentImage = 0;
   state.recording.recordings = [];
   state.recording.currentBlob = null;
-  if (!state.consentStatus.consent2 || state.consentStatus.videoDeclined) {
+  if (!hasVideoConsent()) {
     document.getElementById('recording-consent-check').style.display = 'block';
     document.getElementById('recording-content').style.display = 'none';
   } else {

--- a/src/main.js
+++ b/src/main.js
@@ -1258,11 +1258,26 @@ function openExternalTask(taskCode) {
 }
 
     // ----- Recording task -----
+    function hasVideoConsent() {
+      if (state.consentStatus.consent2 || state.consentStatus.videoDeclined) return true;
+      try {
+        const recent = localStorage.getItem('recent_session');
+        if (!recent) return false;
+        const saved = localStorage.getItem(`study_${recent}`);
+        if (!saved) return false;
+        const data = JSON.parse(saved);
+        return !!(data.consentStatus && (data.consentStatus.consent2 || data.consentStatus.videoDeclined));
+      } catch (e) {
+        console.warn('Could not check saved consent', e);
+        return false;
+      }
+    }
+
     function showRecordingTask() {
       state.recording.currentImage = 0;
       state.recording.recordings = [];
       state.recording.currentBlob = null;
-      if (!state.consentStatus.consent2 || state.consentStatus.videoDeclined) {
+      if (!hasVideoConsent()) {
         document.getElementById('recording-consent-check').style.display = 'block';
         document.getElementById('recording-content').style.display = 'none';
       } else {


### PR DESCRIPTION
## Summary
- Skip video consent prompt in image description task if consent was previously recorded
- Include helper `hasVideoConsent` to detect prior consent from local storage

## Testing
- `npm run lint` *(fails: Expected indentation of 2 spaces but found 6, 'Uint8Array' is not defined)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0da83f0bc8326801a1fdc9ea50a11