### PR TITLE
Direct contact buttons to lab email

### DIFF
--- a/main.js
+++ b/main.js
@@ -2361,7 +2361,7 @@ What I've tried:
 Accessibility needs (if any): 
 
 Thank you!`);
-    window.open(`mailto:${CONFIG.SUPPORT_EMAIL}?subject=${subject}&body=${body}`, "_blank");
+    window.location.href = `mailto:${CONFIG.SUPPORT_EMAIL}?subject=${subject}&body=${body}`;
   }
   async function skipTaskProceed(taskCode) {
     if (taskCode === "ID") {

--- a/src/main.js
+++ b/src/main.js
@@ -2450,7 +2450,7 @@ What I've tried:
 Accessibility needs (if any): 
 
 Thank you!`);
-  window.open(`mailto:${CONFIG.SUPPORT_EMAIL}?subject=${subject}&body=${body}`, '_blank');
+  window.location.href = `mailto:${CONFIG.SUPPORT_EMAIL}?subject=${subject}&body=${body}`;
 }
 
 // Do the actual skip (handles video task cleanup)


### PR DESCRIPTION
## Summary
- Ensure openSupportEmail uses `mailto:action.brain.lab@gallaudet.edu` so help buttons open the user's email client directly

## Testing
- `npm run build`
- `npm run lint`
- `npm start` *(fails: Missing configuration values: SHEETS_URL, CLOUDINARY_CLOUD_NAME, CLOUDINARY_UPLOAD_PRESET)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ec1aa3a08326beb8b605b26ca50f