### PR TITLE
Validate resume session codes

### DIFF
--- a/main.js
+++ b/main.js
@@ -11,6 +11,7 @@
     CLOUDINARY_UPLOAD_PRESET: "study_videos",
     CLOUDINARY_FOLDER: "spatial-cognition-videos"
   };
+  var CODE_REGEX = /^[A-Z0-9]{8}$/;
 
   // src/tasks.js
   var TASKS = {
@@ -879,8 +880,8 @@ Session code: ${state.sessionCode || ""}`);
   }
   async function resumeSession(codeFromLink) {
     const input = codeFromLink || document.getElementById("resume-code").value;
-    const code = input.toUpperCase();
-    if (code.length !== 8) {
+    const code = input.trim().toUpperCase();
+    if (!CODE_REGEX.test(code)) {
       alert("Please enter your 8-character resume code");
       return;
     }

--- a/src/config.js
+++ b/src/config.js
@@ -10,4 +10,4 @@ export const CONFIG = {
   CLOUDINARY_FOLDER: 'spatial-cognition-videos',
 };
 
-export const CODE_REGEX = /^\d{6}$/;
+export const CODE_REGEX = /^[A-Z0-9]{8}$/;

--- a/src/main.js
+++ b/src/main.js
@@ -527,8 +527,8 @@ function showScreen(screenId) {
 
       async function resumeSession(codeFromLink) {
         const input = codeFromLink || document.getElementById('resume-code').value;
-        const code = input.toUpperCase();
-        if (code.length !== 8) { alert('Please enter your 8-character resume code'); return; }
+        const code = input.trim().toUpperCase();
+        if (!CODE_REGEX.test(code)) { alert('Please enter your 8-character resume code'); return; }
       try {
         const res = await fetch(CONFIG.SHEETS_URL, {
           method: 'POST',


### PR DESCRIPTION
## Summary
- Trim and validate resume codes before fetching session data
- Enforce 8-character alphanumeric resume code format

## Testing
- `npm run build`
- `npm run lint`
- `SHEETS_URL=http://example.com CLOUDINARY_CLOUD_NAME=demo CLOUDINARY_UPLOAD_PRESET=demo npm start`

------
https://chatgpt.com/codex/tasks/task_e_68b0efc53d948326b6d25591e20d4303