### PR TITLE
Fix consent code validation and sanitize session lookup

### DIFF
--- a/google-apps-script.gs
+++ b/google-apps-script.gs
@@ -2275,6 +2275,8 @@ function logEvent(ss, data) {
 function getSessionData(ss, sessionCode) {
   if (!sessionCode) return createCorsOutput({ success: false, error: 'Missing sessionCode' });
 
+  sessionCode = String(sessionCode).trim().toUpperCase();
+
   var sheet = ss.getSheetByName('Sessions');
   var data = sheet.getDataRange().getValues();
   var headers = data[0].map(function (v) { return String(v || ''); });

--- a/main.js
+++ b/main.js
@@ -12,6 +12,7 @@
     CLOUDINARY_FOLDER: "spatial-cognition-videos"
   };
   var CODE_REGEX = /^[A-Z0-9]{8}$/;
+  var CONSENT_CODE_REGEX = /^\d{6}$/;
 
   // src/tasks.js
   var TASKS = {
@@ -980,6 +981,17 @@ Session code: ${state.sessionCode || ""}`);
       sendToSheets({ action: "consent_opened", sessionCode: state.sessionCode, type, timestamp: (/* @__PURE__ */ new Date()).toISOString() });
     }
   }
+  function toggleCodeEntry(type) {
+    const container = document.getElementById(`${type}-code-container`);
+    const note = document.getElementById(`${type}-verify-note`);
+    if (!container) return;
+    const show = container.style.display === "none" || container.style.display === "";
+    container.style.display = show ? "block" : "none";
+    if (show && note) {
+      note.textContent = "\u{1F504} Waiting for consent form code...";
+      note.style.color = "var(--text-secondary)";
+    }
+  }
   function markConsentDone(type) {
     const niceName = type === "consent1" ? "Research Consent" : "Video Consent";
     const ok = confirm(
@@ -1012,6 +1024,36 @@ This helps prevent accidental or invalid confirmation.`
       timestamp: (/* @__PURE__ */ new Date()).toISOString()
     });
     logSessionTime(type);
+  }
+  function verifyConsentCode(type) {
+    const inputId = type === "consent1" ? "consent1-code" : "consent2-code";
+    const noteId = type === "consent1" ? "consent1-verify-note" : "consent2-verify-note";
+    const el = document.getElementById(inputId);
+    const noteEl = document.getElementById(noteId);
+    const code = (el && el.value || "").trim();
+    if (!CONSENT_CODE_REGEX.test(code)) {
+      alert("Enter the 6-digit code shown at the end of the Qualtrics form.");
+      if (el) el.focus();
+      return;
+    }
+    if (type === "consent1") state.consentStatus.consent1 = true;
+    if (type === "consent2") state.consentStatus.consent2 = true;
+    state.consentVerify[type] = { verified: true, method: "code", note: "6-digit" };
+    saveState();
+    updateConsentDisplay();
+    if (noteEl) {
+      noteEl.textContent = "\u2705 Code verified!";
+      noteEl.style.color = "#1b5e20";
+    }
+    sendToSheets({
+      action: "consent_verified",
+      sessionCode: state.sessionCode || "none",
+      type,
+      method: "code",
+      codeSuffix: code,
+      // already 6 digits
+      timestamp: (/* @__PURE__ */ new Date()).toISOString()
+    });
   }
   function autoVerifyConsentsFromURL() {
     try {
@@ -2465,6 +2507,9 @@ Thank you!`);
     showSkipDialog,
     skipCurrentTask,
     skipTask,
-    skipTaskProceed
+    skipTaskProceed,
+    // Consent helpers
+    toggleCodeEntry,
+    verifyConsentCode
   });
 })();

--- a/src/config.js
+++ b/src/config.js
@@ -11,3 +11,4 @@ export const CONFIG = {
 };
 
 export const CODE_REGEX = /^[A-Z0-9]{8}$/;
+export const CONSENT_CODE_REGEX = /^\d{6}$/;

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-import { CONFIG, CODE_REGEX } from './config.js';
+import { CONFIG, CODE_REGEX, CONSENT_CODE_REGEX } from './config.js';
 import {
   TASKS,
   getStandardTaskName,
@@ -688,7 +688,7 @@ function verifyConsentCode(type) {
   const code = ((el && el.value) || '').trim();
 
   // Enforce 6 digits only
-  if (!CODE_REGEX.test(code)) {
+  if (!CONSENT_CODE_REGEX.test(code)) {
     alert('Enter the 6-digit code shown at the end of the Qualtrics form.');
     if (el) el.focus();
     return;
@@ -2566,6 +2566,10 @@ Object.assign(window, {
   showSkipDialog,
   skipCurrentTask,
   skipTask,
-  skipTaskProceed
+  skipTaskProceed,
+
+  // Consent helpers
+  toggleCodeEntry,
+  verifyConsentCode
 });
 


### PR DESCRIPTION
## Summary
- validate consent codes with a dedicated 6-digit regex
- expose consent verification helpers to the browser
- trim and uppercase session codes before lookup on Apps Script backend

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0f359fd2c832688bbc4ca0fda234e