### PR TITLE
Allow alphanumeric consent codes and standardize fetch headers

### DIFF
--- a/main.js
+++ b/main.js
@@ -12,7 +12,7 @@
     CLOUDINARY_FOLDER: "spatial-cognition-videos"
   };
   var CODE_REGEX = /^[A-Z0-9]{8}$/;
-  var CONSENT_CODE_REGEX = /^\d{6}$/;
+  var CONSENT_CODE_REGEX = /^[A-Z0-9]{6}$/;
 
   // src/tasks.js
   var TASKS = {
@@ -1030,15 +1030,15 @@ This helps prevent accidental or invalid confirmation.`
     const noteId = type === "consent1" ? "consent1-verify-note" : "consent2-verify-note";
     const el = document.getElementById(inputId);
     const noteEl = document.getElementById(noteId);
-    const code = (el && el.value || "").trim();
+    const code = (el && el.value || "").trim().toUpperCase();
     if (!CONSENT_CODE_REGEX.test(code)) {
-      alert("Enter the 6-digit code shown at the end of the Qualtrics form.");
+      alert("Enter the 6-character code shown at the end of the Qualtrics form.");
       if (el) el.focus();
       return;
     }
     if (type === "consent1") state.consentStatus.consent1 = true;
     if (type === "consent2") state.consentStatus.consent2 = true;
-    state.consentVerify[type] = { verified: true, method: "code", note: "6-digit" };
+    state.consentVerify[type] = { verified: true, method: "code", note: "6-character" };
     saveState();
     updateConsentDisplay();
     if (noteEl) {
@@ -2445,7 +2445,7 @@ Thank you!`);
       await fetch(CONFIG.SHEETS_URL, {
         method: "POST",
         mode: "no-cors",
-        headers: { "Content-Type": "text/plain" },
+        headers: { "Content-Type": "text/plain;charset=utf-8" },
         // simple request, bypasses CORS preflight
         body: JSON.stringify(body)
       });

--- a/src/config.js
+++ b/src/config.js
@@ -11,4 +11,4 @@ export const CONFIG = {
 };
 
 export const CODE_REGEX = /^[A-Z0-9]{8}$/;
-export const CONSENT_CODE_REGEX = /^\d{6}$/;
+export const CONSENT_CODE_REGEX = /^[A-Z0-9]{6}$/;

--- a/src/main.js
+++ b/src/main.js
@@ -685,11 +685,11 @@ function verifyConsentCode(type) {
 
   const el = document.getElementById(inputId);
   const noteEl = document.getElementById(noteId);
-  const code = ((el && el.value) || '').trim();
+  const code = ((el && el.value) || '').trim().toUpperCase();
 
-  // Enforce 6 digits only
+  // Enforce 6 alphanumeric characters
   if (!CONSENT_CODE_REGEX.test(code)) {
-    alert('Enter the 6-digit code shown at the end of the Qualtrics form.');
+    alert('Enter the 6-character code shown at the end of the Qualtrics form.');
     if (el) el.focus();
     return;
   }
@@ -698,7 +698,7 @@ function verifyConsentCode(type) {
   if (type === 'consent1') state.consentStatus.consent1 = true;
   if (type === 'consent2') state.consentStatus.consent2 = true;
 
-  state.consentVerify[type] = { verified: true, method: 'code', note: '6-digit' };
+  state.consentVerify[type] = { verified: true, method: 'code', note: '6-character' };
   saveState();
   updateConsentDisplay();
 
@@ -2491,7 +2491,7 @@ async function sendToSheets(payload) {
     await fetch(CONFIG.SHEETS_URL, {
       method: 'POST',
       mode: 'no-cors',
-      headers: { 'Content-Type': 'text/plain' }, // simple request, bypasses CORS preflight
+      headers: { 'Content-Type': 'text/plain;charset=utf-8' }, // simple request, bypasses CORS preflight
       body: JSON.stringify(body)
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
- Allow six-character alphanumeric consent codes and uppercase user input before validation
- Use text/plain;charset=utf-8 for all Sheets fetches to avoid CORS preflight issues

## Testing
- ✅ `npm run lint`
- ✅ `npm run build`
- ✅ `SHEETS_URL=http://example.com CLOUDINARY_CLOUD_NAME=demo CLOUDINARY_UPLOAD_PRESET=preset npm start`

------
https://chatgpt.com/codex/tasks/task_e_68b0f684f400832681a2f1a4e3c70b73