### PR TITLE
fix: remove optional chaining for Safari compatibility

### DIFF
--- a/main.js
+++ b/main.js
@@ -360,8 +360,9 @@
     canvas.width = 64;
     canvas.height = 64;
     const ctx = canvas.getContext("2d");
-    const mime = MediaRecorder?.isTypeSupported?.("video/webm;codecs=vp9") ? "video/webm;codecs=vp9" : MediaRecorder?.isTypeSupported?.("video/webm;codecs=vp8") ? "video/webm;codecs=vp8" : "video/webm";
-    const stream = canvas.captureStream?.(fps);
+    const canCheckType = typeof MediaRecorder !== "undefined" && typeof MediaRecorder.isTypeSupported === "function";
+    const mime = canCheckType && MediaRecorder.isTypeSupported("video/webm;codecs=vp9") ? "video/webm;codecs=vp9" : canCheckType && MediaRecorder.isTypeSupported("video/webm;codecs=vp8") ? "video/webm;codecs=vp8" : "video/webm";
+    const stream = canvas.captureStream ? canvas.captureStream(fps) : null;
     if (!stream) throw new Error("Canvas captureStream is not supported in this browser");
     const rec = new MediaRecorder(stream, { mimeType: mime, videoBitsPerSecond: 25e4 });
     const chunks = [];
@@ -403,7 +404,7 @@
       input.type = "file";
       input.accept = "video/mp4,video/webm,video/quicktime";
       input.click();
-      const file = await new Promise((resolve) => input.onchange = () => resolve(input.files?.[0]));
+      const file = await new Promise((resolve) => input.onchange = () => resolve(input.files && input.files[0]));
       if (!file) {
         alert("No file selected.");
         return;

--- a/src/debug.js
+++ b/src/debug.js
@@ -108,11 +108,11 @@ async function makeTinyTestVideo({ ms = 800, fps = 10 } = {}) {
   const canvas = document.createElement('canvas');
   canvas.width = 64; canvas.height = 64;
   const ctx = canvas.getContext('2d');
-  const mime =
-    MediaRecorder?.isTypeSupported?.('video/webm;codecs=vp9') ? 'video/webm;codecs=vp9' :
-    MediaRecorder?.isTypeSupported?.('video/webm;codecs=vp8') ? 'video/webm;codecs=vp8' :
-    'video/webm';
-  const stream = canvas.captureStream?.(fps);
+  const canCheckType = (typeof MediaRecorder !== 'undefined' && typeof MediaRecorder.isTypeSupported === 'function');
+  const mime = canCheckType && MediaRecorder.isTypeSupported('video/webm;codecs=vp9') ? 'video/webm;codecs=vp9'
+    : canCheckType && MediaRecorder.isTypeSupported('video/webm;codecs=vp8') ? 'video/webm;codecs=vp8'
+    : 'video/webm';
+  const stream = canvas.captureStream ? canvas.captureStream(fps) : null;
   if (!stream) throw new Error('Canvas captureStream is not supported in this browser');
   const rec = new MediaRecorder(stream, { mimeType: mime, videoBitsPerSecond: 250000 });
   const chunks = [];
@@ -153,7 +153,7 @@ export async function testCloudinaryUpload() {
     input.type = 'file';
     input.accept = 'video/mp4,video/webm,video/quicktime';
     input.click();
-    const file = await new Promise(resolve => input.onchange = () => resolve(input.files?.[0]));
+    const file = await new Promise(resolve => input.onchange = () => resolve(input.files && input.files[0]));
     if (!file) { alert('No file selected.'); return; }
     blob = file;
   }


### PR DESCRIPTION
## Summary
- replace optional chaining in debug helpers to avoid parse errors on older Safari
- rebuild main.js without optional chaining

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0f80d44948326aa2b97e69ebfec9f