### PR TITLE
fix: unblock consent progression

### DIFF
--- a/main.js
+++ b/main.js
@@ -1170,7 +1170,7 @@ This helps prevent accidental or invalid confirmation.`
     return false;
   }
   function updateConsentDisplay() {
-    checkVideoConsent().then(() => {
+    const render = () => {
       const c1 = state.consentStatus.consent1;
       const c2 = state.consentStatus.consent2 || state.consentStatus.videoDeclined;
       document.getElementById("continue-from-consent").disabled = !(c1 && c2);
@@ -1212,7 +1212,9 @@ This helps prevent accidental or invalid confirmation.`
           note.style.color = "#856404";
         }
       }
-    });
+    };
+    render();
+    checkVideoConsent().then(render).catch((err) => console.warn("checkVideoConsent failed", err));
   }
   function proceedToTasks() {
     if (!state.consentStatus.consent1) {

--- a/src/main.js
+++ b/src/main.js
@@ -840,7 +840,7 @@ document.addEventListener('DOMContentLoaded', () => {
       return false;
     }
     function updateConsentDisplay() {
-  checkVideoConsent().then(() => {
+  const render = () => {
     const c1 = state.consentStatus.consent1;
     const c2 = state.consentStatus.consent2 || state.consentStatus.videoDeclined;
 
@@ -879,7 +879,10 @@ document.addEventListener('DOMContentLoaded', () => {
         note.style.color = '#856404';
       }
     }
-  });
+  };
+
+  render();
+  checkVideoConsent().then(render).catch(err => console.warn('checkVideoConsent failed', err));
 }
 
     function proceedToTasks() {


### PR DESCRIPTION
## Summary
- render consent status immediately to avoid blocking on background consent check
- fall back gracefully if remote consent check fails

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0fb3974588326aad8d83451b19d13