### PR TITLE
refactor: remove consent flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,23 +157,6 @@
     .code-display { background: linear-gradient(135deg, var(--primary-light) 0%, var(--primary-dark) 100%); color: white; padding: 30px; border-radius: 10px; text-align: center; margin: 20px 0; }
     .code-display .code { font-size: 36px; font-weight: bold; letter-spacing: 3px; margin: 15px 0; font-family: monospace; text-shadow: 2px 2px 4px rgba(0,0,0,0.2); }
 
-    /* Consent grid */
-    .consent-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin: 20px 0; }
-    .consent-card { background: white; border: 2px solid var(--gray-200); border-radius: 10px; padding: 20px; text-align: center; transition: all 0.3s; position: relative; }
-    #consent1-card { background:#f9f9ff; }
-    #consent2-card { background:#f9f9f4; }
-    .consent-card::after { content:'○'; position:absolute; top:10px; right:10px; font-size:24px; color:#bbb; }
-    .consent-card.completed { border-color: var(--success); background: #f1f8f4; }
-    .consent-card.completed::after { content:'✔'; color:var(--success); }
-    .consent-card.declined { border-color: var(--warning); background: #fff9e6; }
-    .consent-card.declined::after { content:'✖'; color:var(--warning); }
-    .consent-card .status-icon { font-size: 48px; margin-bottom: 15px; }
-    .consent-card h4 { color: var(--text-primary); margin-bottom: 10px; }
-    .consent-card p { color: var(--text-secondary); font-size: 14px; margin-bottom: 15px; }
-    .code-note { margin-top: 8px; font-size: 14px; color: var(--text-secondary); }
-    .code-note li { margin-left: 20px; list-style: disc; }
-    .code-entry { margin-top: 12px; background: #f0f9ff; border: 2px dashed var(--info); padding: 15px; border-radius: 8px; }
-    .code-entry input { width: 100%; padding: 12px; border: 2px solid var(--primary); border-radius: 8px; font-size: 16px; }
     .status-indicator { display: block; margin-top: 6px; color: var(--text-secondary); }
     .optional-info summary { cursor: pointer; font-weight: 600; }
 
@@ -257,7 +240,7 @@
       .content { padding: 20px; }
       .card { padding: 20px; }
       .modal-content { padding: 20px; }
-      .form-row, .consent-grid, .video-container { grid-template-columns: 1fr; }
+      .form-row, .video-container { grid-template-columns: 1fr; }
       .session-details { grid-template-columns: 1fr; }
       .button-group { flex-direction: column; }
       .button { width: 100%; }
@@ -539,115 +522,9 @@
         </div>
 
         <div class="button-group" style="margin-top: 20px;">
-          <button class="button primary" onclick="proceedToConsent()">Continue</button>
+          <button class="button primary" onclick="proceedToTasks()">Continue</button>
         </div>
       </div>
-      <div class="screen" id="consent-screen">
-  <h2> Consent Forms</h2>
-<div class="info-box helpful" id="voluntary-consent-box" style="margin-top: 12px;">
-  <strong>IMPORTANT: Please Read</strong>
-  <ul style="margin: 8px 0 0 20px; text-align: left;">
-    <li>Participation in this research study is <strong>VOLUNTARY</strong>.</li>
-    <li>You can withdraw at any time without penalty.</li>
-    <li>We aim to compensate all participants fairly for their time.</li>
-    <li>We encourage completing all tasks for the best research data.</li>
-    <li>Having technical issues or need accommodations? Email us!</li>
-  </ul>
-</div>
-
-  <!-- NEW: prominent warning -->
-  <div class="info-box important" style="margin: 12px 0 20px;">
-    <strong>⚠️ IMPORTANT:</strong>
-    <p style="margin-top: 8px;">
-      You must actually complete these Qualtrics consent forms. Simply clicking “I completed this form”
-      without submitting the form will <u>invalidate your participation</u>.
-    </p>
-  </div>
-
-  <div class="info-box friendly-tip" role="status" style="margin-top: 12px;">
-    Participation is your choice. We ask that you try every task. Your answers help our research the most when you complete all tasks. There is no judgment. Try your best. If you have trouble, email us at <a class="support-email"></a> for help instead of skipping.
-  </div>
-
-  <p style="color: var(--text-secondary); margin-bottom: 16px;">
-    If you already completed these in the Qualtrics screener, you can verify with a code (optional) or affirm completion below.
-  </p>
-
-  <div class="card" id="consent-steps">
-    <h3 style="margin-bottom:8px;">Steps to complete the consent forms</h3>
-    <ol style="margin-left:20px; text-align:left;">
-      <li>Click <strong>1. Open Form in New Tab</strong>.</li>
-      <li>Fill out the form. A code will appear at the end.</li>
-      <li>Copy the code, then return to this page.</li>
-      <li>Click <strong>2. Enter Code from Form</strong>, paste the code, and press <strong>Verify code</strong>.</li>
-      <li>If you've already done the form, choose <strong>Skip Code Entry (already completed)</strong>.</li>
-    </ol>
-    <p class="code-note">You can switch between tabs without losing progress.</p>
-  </div>
-
-  <div class="consent-grid">
-    <!-- Consent 1 -->
-    <div class="consent-card" id="consent1-card">
-      <div class="status-icon">📄</div>
-      <h4>Research Consent</h4>
-      <p>General study participation consent (required)</p>
-      <ul class="code-note">
-        <li>The consent form will show a code at the end.</li>
-        <li>Copy that code and paste it here.</li>
-        <li>You can switch between tabs to copy/paste.</li>
-      </ul>
-      <div class="button-group" style="justify-content:center;">
-        <button class="button optional" onclick="openConsent('CONSENT1')">1. Open Form in New Tab</button>
-        <button class="button friendly" onclick="toggleCodeEntry('consent1')">2. Enter Code from Form</button>
-        <button class="button outline" onclick="markConsentDone('consent1')">Skip Code Entry (already completed)</button>
-      </div>
-      <div id="consent1-code-container" class="code-entry" style="display:none;">
-        <input id="consent1-code" type="text" placeholder="Paste the code from the consent form here">
-        <div class="button-group" style="justify-content:flex-start; margin-top:10px;">
-          <button class="button secondary" onclick="verifyConsentCode('consent1')">Verify code</button>
-        </div>
-        <small id="consent1-verify-note" class="status-indicator">🔄 Waiting for consent form code...</small>
-      </div>
-    </div>
-
-    <!-- Consent 2 -->
-    <div class="consent-card" id="consent2-card">
-      <div class="status-icon">🎥</div>
-      <h4>Video Consent</h4>
-      <p>For the image description recording task (optional)</p>
-      <ul class="code-note">
-        <li>The consent form will show a code at the end.</li>
-        <li>Copy that code and paste it here.</li>
-        <li>You can switch between tabs to copy/paste.</li>
-      </ul>
-      <div class="button-group" style="justify-content:center;">
-        <button class="button optional" onclick="openConsent('CONSENT2')">1. Open Form in New Tab</button>
-        <button class="button friendly" onclick="toggleCodeEntry('consent2')">2. Enter Code from Form</button>
-        <button class="button outline" onclick="markConsentDone('consent2')">Skip Code Entry (already completed)</button>
-        <button class="button secondary" onclick="declineVideo()">Decline Video</button>
-      </div>
-      <div id="consent2-code-container" class="code-entry" style="display:none;">
-        <input id="consent2-code" type="text" placeholder="Paste the code from the consent form here">
-        <div class="button-group" style="justify-content:flex-start; margin-top:10px;">
-          <button class="button secondary" onclick="verifyConsentCode('consent2')">Verify code</button>
-        </div>
-        <small id="consent2-verify-note" class="status-indicator">🔄 Waiting for consent form code...</small>
-      </div>
-    </div>
-  </div>
-
-  <div class="info-box helpful" style="margin-top: 10px;">
-    <strong>Prefer automatic verification?</strong>
-    <p style="margin-top:6px;">
-      If your Qualtrics forms redirect back here with a confirmation parameter, we’ll auto-verify them.
-      (You can also paste a code above.)
-    </p>
-  </div>
-
-  <button class="button primary" id="continue-from-consent" onclick="proceedToTasks()" disabled
-          style="display: block; margin: 20px auto;">
-    Continue to Study Tasks
-  </button>
-</div>
 
       <!-- Progress -->
       <div class="screen" id="progress-screen">
@@ -692,15 +569,6 @@
       <!-- Recording -->
       <div class="screen" id="recording-screen">
         <h2>Image Description Task</h2>
-
-        <div class="info-box important" id="recording-consent-check" style="display: none;">
-          <strong>Video consent required</strong>
-          <p>Please complete the video consent form to proceed with this task.</p>
-          <div class="button-group" style="margin-top: 10px;">
-            <button class="button optional" onclick="openConsent('CONSENT2')">Open Video Consent</button>
-            <button class="button skip" id="skip-recording-consent-btn">Unable to complete</button>
-          </div>
-        </div>
 
         <div id="recording-content" style="display: none;">
           <div class="info-box helpful">

--- a/src/config.js
+++ b/src/config.js
@@ -11,4 +11,3 @@ export const CONFIG = {
 };
 
 export const CODE_REGEX = /^[A-Z0-9]{8}$/;
-export const CONSENT_CODE_REGEX = /^[A-Z0-9]{6}$/;

--- a/src/main.js
+++ b/src/main.js
@@ -1,8 +1,7 @@
-import { CONFIG, CODE_REGEX, CONSENT_CODE_REGEX } from './config.js';
+import { CONFIG, CODE_REGEX } from './config.js';
 import {
   TASKS,
   getStandardTaskName,
-  CONSENTS,
   DESKTOP_TASKS,
   MOBILE_TASKS,
   mulberry32,
@@ -74,14 +73,6 @@ function closeEEGModal() {
   pauseStart: null,
   totalPausedTime: 0,
   lastPauseType: null,
-
-  consentStatus: { consent1: false, consent2: false, videoDeclined: false },
-
-  // ⬇️ ADD THIS INSIDE THE STATE OBJECT
-  consentVerify: {
-    consent1: { verified: false, method: null, note: '' },
-    consent2: { verified: false, method: null, note: '' }
-  },
 
   recording: {
     active: false, mediaRecorder: null, chunks: [], currentImage: 0, recordings: [],
@@ -430,8 +421,7 @@ function showScreen(screenId) {
   updateProgressBar();
 
   const crumbs = ['Home'];
-  if (screenId === 'consent-screen') crumbs.push('Consent');
-  else if (screenId === 'eeg-info') crumbs.push('EEG Info');
+  if (screenId === 'eeg-info') crumbs.push('EEG Info');
   else if (screenId === 'progress-screen') crumbs.push('Tasks');
   else if (screenId === 'task-screen' || screenId === 'recording-screen') {
     crumbs.push('Tasks');
@@ -443,7 +433,7 @@ function showScreen(screenId) {
 
   // Show/hide session widget + FAB
   const widget = document.getElementById('session-widget');
-  const showWidget = ['progress-screen','task-screen','consent-screen','recording-screen'].includes(screenId);
+  const showWidget = ['progress-screen','task-screen','recording-screen'].includes(screenId);
   if (widget) widget.classList.toggle('active', showWidget && state.sessionCode);
   const fab = document.getElementById('pause-fab');
   if (fab) fab.classList.toggle('active', showWidget && state.sessionCode);
@@ -546,7 +536,7 @@ function showScreen(screenId) {
         if (data.activity_summary) state.activity_summary = data.activity_summary;
         saveState();
         updateSessionWidget();
-        if (!state.consentStatus.consent1) showScreen('consent-screen'); else showProgressScreen();
+        showProgressScreen();
         if (!sessionTimer.startTime) sessionTimer.start();
       } catch (err) {
         console.error(err);
@@ -617,276 +607,7 @@ function checkRecoveryLink() {
     function proceedToEEGInfo() {
       showScreen('eeg-info');
     }
-
-    // ----- Consent -----
-    function proceedToConsent() {
-      if (!sessionTimer.startTime) sessionTimer.start();
-      showScreen('consent-screen');
-      updateConsentDisplay();
-    }
-function openConsent(type) {
-  const consent = CONSENTS[type];
-  if (consent) {
-    window.open(consent.url, '_blank', 'noopener');
-    sendToSheets({ action: 'consent_opened', sessionCode: state.sessionCode, type, timestamp: new Date().toISOString() });
-  }
-}
-function toggleCodeEntry(type) {
-  const container = document.getElementById(`${type}-code-container`);
-  const note = document.getElementById(`${type}-verify-note`);
-  if (!container) return;
-  const show = container.style.display === 'none' || container.style.display === '';
-  container.style.display = show ? 'block' : 'none';
-  if (show && note) {
-    note.textContent = '🔄 Waiting for consent form code...';
-    note.style.color = 'var(--text-secondary)';
-  }
-}
-   function markConsentDone(type) {
-  // Safety interlock: explicit warning + typed phrase
-  const niceName = (type === 'consent1') ? 'Research Consent' : 'Video Consent';
-  const ok = confirm(
-    `Did you actually complete and submit the ${niceName} form on Qualtrics?\n\n` +
-    `Clicking “OK” without completing the form will disqualify your participation.`
-  );
-  if (!ok) return;
-
-  const phrase = prompt(
-    `To confirm, type exactly: I COMPLETED THE CONSENT\n\n` +
-    `This helps prevent accidental or invalid confirmation.`
-  );
-
-  if (!phrase || phrase.trim().toUpperCase() !== 'I COMPLETED THE CONSENT') {
-    alert('Not confirmed. Please complete the form first.');
-    return;
-  }
-
-  // Mark the consent as completed (same as before)
-  if (type === 'consent1') {
-    state.consentStatus.consent1 = true;
-  } else if (type === 'consent2') {
-    state.consentStatus.consent2 = true;
-  }
-  saveState(); updateConsentDisplay();
-
-  // Log a stricter audit trail
-  sendToSheets({
-    action: 'consent_affirmed',
-    sessionCode: state.sessionCode,
-    type,
-    method: 'typed-affirmation',
-    timestamp: new Date().toISOString()
-  });
-  logSessionTime(type);
-}
-function verifyConsentCode(type) {
-  const inputId = type === 'consent1' ? 'consent1-code' : 'consent2-code';
-  const noteId  = type === 'consent1' ? 'consent1-verify-note' : 'consent2-verify-note';
-
-  const el = document.getElementById(inputId);
-  const noteEl = document.getElementById(noteId);
-  const code = ((el && el.value) || '').trim().toUpperCase();
-
-  // Enforce 6 alphanumeric characters
-  if (!CONSENT_CODE_REGEX.test(code)) {
-    alert('Enter the 6-character code shown at the end of the Qualtrics form.');
-    if (el) el.focus();
-    return;
-  }
-
-  // Mark this consent complete & verified
-  if (type === 'consent1') state.consentStatus.consent1 = true;
-  if (type === 'consent2') state.consentStatus.consent2 = true;
-
-  state.consentVerify[type] = { verified: true, method: 'code', note: '6-character' };
-  saveState();
-  updateConsentDisplay();
-
-  if (noteEl) {
-    noteEl.textContent = '✅ Code verified!';
-    noteEl.style.color = '#1b5e20';
-  }
-
-  // Log (store only the 6-digit suffix; no PII)
-  sendToSheets({
-    action: 'consent_verified',
-    sessionCode: state.sessionCode || 'none',
-    type,
-    method: 'code',
-    codeSuffix: code,           // already 6 digits
-    timestamp: new Date().toISOString()
-  });
-}
-
-function autoVerifyConsentsFromURL() {
-  try {
-    const p = new URLSearchParams(location.search);
-    // Support: ?c1=1&c2=1 or ?consent1=done etc. You can set these in Qualtrics "End of Survey" redirect.
-    const c1 = p.get('c1') || p.get('consent1');
-    const c2 = p.get('c2') || p.get('consent2');
-    const rid1 = p.get('rid1') || p.get('rid'); // optionally pass ResponseID
-    const rid2 = p.get('rid2');
-
-    if (c1 && String(c1).toLowerCase() !== '0') {
-      state.consentStatus.consent1 = true;
-      state.consentVerify.consent1 = { verified: true, method: 'url-param', note: rid1 ? `RID …${String(rid1).slice(-6)}` : '' };
-      sendToSheets({
-        action: 'consent_verified',
-        sessionCode: state.sessionCode || 'none',
-        type: 'consent1',
-        method: 'url-param',
-        ridSuffix: rid1 ? String(rid1).slice(-6) : '',
-        timestamp: new Date().toISOString()
-      });
-    }
-
-    if (c2 && String(c2).toLowerCase() !== '0') {
-      state.consentStatus.consent2 = true;
-      state.consentVerify.consent2 = { verified: true, method: 'url-param', note: rid2 ? `RID …${String(rid2).slice(-6)}` : '' };
-      sendToSheets({
-        action: 'consent_verified',
-        sessionCode: state.sessionCode || 'none',
-        type: 'consent2',
-        method: 'url-param',
-        ridSuffix: rid2 ? String(rid2).slice(-6) : '',
-        timestamp: new Date().toISOString()
-      });
-    }
-
-    if (c1 || c2) {
-      saveState(); updateConsentDisplay();
-      // Optional: clean query so it doesn't re-trigger on refresh
-      try {
-        const cleanURL = location.origin + location.pathname;
-        window.history.replaceState({}, '', cleanURL);
-      } catch (e) {}
-    }
-  } catch (e) {
-    console.warn('Auto-verify failed', e);
-  }
-}
-
-// Call it during init:
-document.addEventListener('DOMContentLoaded', () => {
-  // ... your existing init
-  autoVerifyConsentsFromURL(); // <— add this line
-});
-
-    function declineVideo() {
-      if (confirm('Decline video consent? You can still participate in other tasks.')) {
-        state.consentStatus.videoDeclined = true;
-        state.consentStatus.consent2 = true;
-        document.getElementById('consent2-card').classList.add('declined');
-        document.querySelector('#consent2-card .status-icon').textContent = '⚠️';
-        saveState(); updateConsentDisplay();
-        sendToSheets({ action: 'video_declined', sessionCode: state.sessionCode, timestamp: new Date().toISOString() });
-        logSessionTime('consent2_declined');
-        updateSessionWidget();
-        updateProgressBar();
-      }
-    }
-
-    async function checkVideoConsent() {
-      if (state.consentStatus.consent2 || state.consentStatus.videoDeclined) return true;
-      try {
-        const saved = localStorage.getItem(`study_${state.sessionCode}`);
-        if (saved) {
-          const s = JSON.parse(saved);
-          if (s.consentStatus && (s.consentStatus.consent2 || s.consentStatus.videoDeclined)) {
-            state.consentStatus = s.consentStatus;
-            return true;
-          }
-        }
-      } catch (_) {}
-
-      if (!state.sessionCode || !CONFIG.SHEETS_URL) return false;
-      try {
-        const res = await fetch(CONFIG.SHEETS_URL, {
-          method: 'POST',
-          headers: { 'Content-Type': 'text/plain;charset=utf-8' },
-          body: JSON.stringify({ action: 'get_session', sessionCode: state.sessionCode })
-        });
-        const data = await res.json();
-        if (data && data.success && data.session) {
-          if (data.session.consent2 || data.session.videoDeclined) {
-            state.consentStatus.consent2 = !!data.session.consent2;
-            state.consentStatus.videoDeclined = !!data.session.videoDeclined;
-            return state.consentStatus.consent2 || state.consentStatus.videoDeclined;
-          }
-          if (data.session.consentStatus) {
-            const cs = String(data.session.consentStatus).toLowerCase();
-            if (cs === 'complete') state.consentStatus.consent2 = true;
-            else if (cs === 'declined') {
-              state.consentStatus.consent2 = true;
-              state.consentStatus.videoDeclined = true;
-            }
-            if (state.consentStatus.consent2 || state.consentStatus.videoDeclined) return true;
-          }
-          if (data.session.state) {
-            try {
-              const st = typeof data.session.state === 'string'
-                ? JSON.parse(data.session.state)
-                : data.session.state;
-              const cs2 = st && st.consentStatus ? st.consentStatus : {};
-              state.consentStatus.consent2 = !!cs2.consent2;
-              state.consentStatus.videoDeclined = !!cs2.videoDeclined;
-              return state.consentStatus.consent2 || state.consentStatus.videoDeclined;
-            } catch (_) {}
-          }
-        }
-      } catch (err) {
-        console.warn('hasVideoConsent fetch failed', err);
-      }
-      return false;
-    }
-    function updateConsentDisplay() {
-  const render = () => {
-    const c1 = state.consentStatus.consent1;
-    const c2 = state.consentStatus.consent2 || state.consentStatus.videoDeclined;
-
-    document.getElementById('continue-from-consent').disabled = !(c1 && c2);
-
-    const card1 = document.getElementById('consent1-card');
-    const card2 = document.getElementById('consent2-card');
-
-    if (c1) {
-      card1.classList.remove('declined');
-      card1.classList.add('completed');
-      card1.querySelector('.status-icon').textContent = '✅';
-
-      const note = document.getElementById('consent1-verify-note');
-      if (state.consentVerify.consent1.verified) {
-        if (note) { note.textContent = '✅ Code verified!'; note.style.color = '#1b5e20'; }
-      } else {
-        if (note) { note.textContent = 'Affirmed without code'; note.style.color = '#856404'; }
-      }
-    }
-
-    if (state.consentStatus.videoDeclined) {
-      card2.classList.remove('completed');
-      card2.classList.add('declined');
-      card2.querySelector('.status-icon').textContent = '⚠️';
-    } else if (state.consentStatus.consent2) {
-      card2.classList.remove('declined');
-      card2.classList.add('completed');
-      card2.querySelector('.status-icon').textContent = '✅';
-
-      const note = document.getElementById('consent2-verify-note');
-      if (state.consentVerify.consent2.verified) {
-        if (note) { note.textContent = '✅ Code verified!'; note.style.color = '#1b5e20'; }
-      } else if (note) {
-        note.textContent = state.consentStatus.consent2 ? 'Affirmed without code' : '';
-        note.style.color = '#856404';
-      }
-    }
-  };
-
-  render();
-  checkVideoConsent().then(render).catch(err => console.warn('checkVideoConsent failed', err));
-}
-
     function proceedToTasks() {
-      if (!state.consentStatus.consent1) { alert('Please complete the research consent form'); return; }
       showProgressScreen();
     }
 
@@ -941,10 +662,9 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     }
     function getTaskCounts() {
-      const isRequired = code => !(code === 'ID' && state.consentStatus.videoDeclined);
       return {
-        total: state.sequence.filter(isRequired).length,
-        completed: state.completedTasks.filter(isRequired).length
+        total: state.sequence.length,
+        completed: state.completedTasks.length
       };
     }
     function updateProgressBar() {
@@ -1041,9 +761,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }
 
       document.getElementById('task-title').textContent = task.name;
-      const requiredText = (taskCode === 'ID' && state.consentStatus.videoDeclined)
-  ? 'This task is optional for you (video consent declined).'
-  : 'This task is required for study completion.';
+      const requiredText = 'This task is required for study completion.';
 const eta = (TASKS[taskCode] && TASKS[taskCode].estMinutes) ? `${TASKS[taskCode].estMinutes} minutes` : 'a few minutes';
 const reqs = (TASKS[taskCode] && TASKS[taskCode].requirements) || '—';
 
@@ -1154,9 +872,7 @@ function showExternalTask(taskCode) {
   const task = TASKS[taskCode];
   let extra = '';
 
-  const requiredText = (taskCode === 'ID' && state.consentStatus.videoDeclined)
-    ? 'This task is OPTIONAL for you (video consent declined).'
-    : 'This task is required for study completion.';
+  const requiredText = 'This task is required for study completion.';
   const eta  = (TASKS[taskCode] && TASKS[taskCode].estMinutes) ? `${TASKS[taskCode].estMinutes} minutes` : 'a few minutes';
   const reqs = (TASKS[taskCode] && TASKS[taskCode].requirements) || '—';
 
@@ -1249,37 +965,14 @@ function openExternalTask(taskCode) {
 }
 
     // ----- Recording task -----
-    function hasStoredVideoConsent() {
-      if (state.consentStatus.consent2 || state.consentStatus.videoDeclined) return true;
-      try {
-        const recent = localStorage.getItem('recent_session');
-        if (!recent) return false;
-        const saved = localStorage.getItem(`study_${recent}`);
-        if (!saved) return false;
-        const data = JSON.parse(saved);
-        return !!(data.consentStatus && (data.consentStatus.consent2 || data.consentStatus.videoDeclined));
-      } catch (e) {
-        console.warn('Could not check saved consent', e);
-        return false;
-      }
-    }
-
     function showRecordingTask() {
       state.recording.currentImage = 0;
       state.recording.recordings = [];
       state.recording.currentBlob = null;
-      if (!hasStoredVideoConsent()) {
-        document.getElementById('recording-consent-check').style.display = 'block';
-        document.getElementById('recording-content').style.display = 'none';
-      } else {
-        document.getElementById('recording-consent-check').style.display = 'none';
-        document.getElementById('recording-content').style.display = 'block';
-        updateRecordingImage();
-      }
+      document.getElementById('recording-content').style.display = 'block';
+      updateRecordingImage();
       // NEW: if page not secure, skip recorder UI and show upload UI
       if (!window.isSecureContext) {
-        document.getElementById('recording-consent-check').style.display = 'none';
-        document.getElementById('recording-content').style.display = 'block';
         document.getElementById('video-upload-fallback').style.display = 'block';
         // Ensure the current image is shown even without recording
         updateRecordingImage();
@@ -1390,9 +1083,7 @@ function openExternalTask(taskCode) {
       recordingControls.parentNode.insertBefore(recordingInstructions, recordingControls);
       }
 
-      const requiredTextRec = (state.consentStatus.videoDeclined)
-  ? 'This task is OPTIONAL for you (video consent declined).'
-  : 'This task is required for study completion.';
+      const requiredTextRec = 'This task is required for study completion.';
 const etaRec = (TASKS['ID'] && TASKS['ID'].estMinutes) ? `${TASKS['ID'].estMinutes} minutes` : 'a few minutes';
 const reqsRec = (TASKS['ID'] && TASKS['ID'].requirements) || '—';
 
@@ -1537,8 +1228,6 @@ if (instructionBox) {
 function bindRecordingSkips() {
       const btn1 = document.getElementById('skip-recording-btn');
       if (btn1) btn1.addEventListener('click', () => showSkipDialog('ID'));
-      const btn2 = document.getElementById('skip-recording-consent-btn');
-      if (btn2) btn2.addEventListener('click', () => showSkipDialog('ID'));
     }
 
     async function toggleRecording() {
@@ -2215,7 +1904,7 @@ function continueWithoutUpload() {
         action: 'task_skipped',
         sessionCode: state.sessionCode,
         task: getStandardTaskName(taskCode),
-        reason: taskCode === 'ASLCT' ? 'Does not know ASL' : taskCode === 'ID' ? (state.consentStatus.videoDeclined ? 'Video consent declined' : 'User chose to skip') : 'User chose to skip',
+        reason: taskCode === 'ASLCT' ? 'Does not know ASL' : 'User chose to skip',
         timestamp: new Date().toISOString(),
         deviceType: state.isMobile ? 'mobile/tablet' : 'desktop'
       });
@@ -2531,12 +2220,8 @@ Object.assign(window, {
   openSupportEmail,
   tryMailto,
 
-  // Consent and EEG flow handlers
+  // EEG flow handlers
   closeEEGModal,
-  declineVideo,
-  markConsentDone,
-  openConsent,
-  proceedToConsent,
   proceedToEEGInfo,
 
   // Debug utilities
@@ -2571,8 +2256,6 @@ Object.assign(window, {
   skipTask,
   skipTaskProceed,
 
-  // Consent helpers
-  toggleCodeEntry,
-  verifyConsentCode
+  
 });
 

--- a/src/tasks.js
+++ b/src/tasks.js
@@ -21,11 +21,6 @@ export function getStandardTaskName(taskCode) {
   return mapping[taskCode] || (TASKS[taskCode] ? TASKS[taskCode].name : undefined) || taskCode;
 }
 
-export const CONSENTS = {
-  'CONSENT1': { name: 'Research Consent', url: 'https://gallaudet.iad1.qualtrics.com/jfe/form/SV_cGZEQDXQpUbGq1g' },
-  'CONSENT2': { name: 'Video Consent', url: 'https://gallaudet.iad1.qualtrics.com/jfe/form/SV_5j0XhME387Kii8u' }
-};
-
 export const DESKTOP_TASKS = ['RC', 'MRT', 'ASLCT', 'VCN', 'SN', 'ID'];
 export const MOBILE_TASKS = ['RC', 'MRT', 'ASLCT', 'SN', 'ID'];
 


### PR DESCRIPTION
## Summary
- remove on-portal consent flow and direct users straight to tasks
- simplify task counting and recording flow now that consents are external

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0ff1f7a9c8326a99159ca486e2fc6