### PR TITLE
fix: ensure video preview plays during recording

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2255,7 +2255,10 @@ Object.assign(window, {
   skipCurrentTask,
   skipTask,
   skipTaskProceed,
+  toggleRecording,
+  reRecord,
+  saveRecording,
 
-  
+
 });
 


### PR DESCRIPTION
## Summary
- expose recording controls to the global window
- rebuild main.js so video preview plays when recording starts

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b10155cce883269bd53407f44652c8