### PR TITLE
Prompt consent confirmation and code entry on registration

### DIFF
--- a/index.html
+++ b/index.html
@@ -361,6 +361,20 @@
         <h2>New Participant Registration</h2>
         <p style="color: var(--text-secondary); margin-bottom: 30px;">Create your unique session to track your progress</p>
 
+        <p style="margin-bottom: 20px;">Please confirm you have completed the consent form and enter the access code provided on Qualtrics.</p>
+
+        <div class="form-group">
+          <label for="consent-code">Consent Access Code</label>
+          <input type="text" id="consent-code" placeholder="e.g., ABC123" />
+        </div>
+
+        <div class="form-group">
+          <label style="display: flex; align-items: center; gap: 10px;">
+            <input type="checkbox" id="consent-confirm" />
+            I have completed the consent form
+          </label>
+        </div>
+
         <div class="form-row">
           <div class="form-group">
             <label for="first-initial">First Name Initial</label>

--- a/main.js
+++ b/main.js
@@ -768,6 +768,8 @@ Session code: ${state.sessionCode || ""}`);
     document.getElementById("last-initial").addEventListener("input", validateInitials);
     document.getElementById("hearing-status").addEventListener("change", validateInitials);
     document.getElementById("fluency").addEventListener("change", validateInitials);
+    document.getElementById("consent-code").addEventListener("input", validateInitials);
+    document.getElementById("consent-confirm").addEventListener("change", validateInitials);
     document.getElementById("resume-code").addEventListener("input", (e) => {
       e.target.value = e.target.value.toUpperCase();
     });
@@ -783,7 +785,9 @@ Session code: ${state.sessionCode || ""}`);
     const last = document.getElementById("last-initial").value;
     const hearing = document.getElementById("hearing-status").value;
     const fluency = document.getElementById("fluency").value;
-    document.getElementById("create-session-btn").disabled = !(first && last && hearing && fluency);
+    const consentCode = document.getElementById("consent-code").value;
+    const consent = document.getElementById("consent-confirm").checked;
+    document.getElementById("create-session-btn").disabled = !(first && last && hearing && fluency && consentCode && consent);
   }
   function showScreen(screenId) {
     document.querySelectorAll(".screen").forEach((s) => s.classList.remove("active"));
@@ -826,8 +830,10 @@ Session code: ${state.sessionCode || ""}`);
     const email = document.getElementById("email").value.trim();
     const hearing = document.getElementById("hearing-status").value;
     const fluency = document.getElementById("fluency").value;
-    if (!first || !last || !hearing || !fluency) {
-      alert("Please complete all fields");
+    const consentCode = document.getElementById("consent-code").value.trim();
+    const consent = document.getElementById("consent-confirm").checked;
+    if (!first || !last || !hearing || !fluency || !consentCode || !consent) {
+      alert("Please complete all fields and confirm consent");
       return;
     }
     if (isMobileDevice()) {
@@ -841,6 +847,8 @@ Session code: ${state.sessionCode || ""}`);
     state.email = email;
     state.hearingStatus = hearing;
     state.fluency = fluency;
+    state.consentCode = consentCode;
+    state.consentConfirmed = consent;
     const seed = Math.abs(hashCode(state.sessionCode));
     state.sequenceIndex = seed;
     if (isMobileDevice()) {
@@ -861,6 +869,8 @@ Session code: ${state.sessionCode || ""}`);
       email: state.email,
       hearingStatus: state.hearingStatus,
       fluency: state.fluency,
+      consentCode: state.consentCode,
+      consentConfirmed: state.consentConfirmed,
       deviceType: state.isMobile ? "mobile/tablet" : "desktop",
       timestamp: (/* @__PURE__ */ new Date()).toISOString()
     });

--- a/src/main.js
+++ b/src/main.js
@@ -393,6 +393,8 @@ if (document.readyState === 'loading') {
       document.getElementById('last-initial').addEventListener('input', validateInitials);
       document.getElementById('hearing-status').addEventListener('change', validateInitials);
       document.getElementById('fluency').addEventListener('change', validateInitials);
+      document.getElementById('consent-code').addEventListener('input', validateInitials);
+      document.getElementById('consent-confirm').addEventListener('change', validateInitials);
       document.getElementById('resume-code').addEventListener('input', e => { e.target.value = e.target.value.toUpperCase(); });
       bindRecordingSkips();
       enhanceUploadFallback();
@@ -407,7 +409,9 @@ if (document.readyState === 'loading') {
       const last = document.getElementById('last-initial').value;
       const hearing = document.getElementById('hearing-status').value;
       const fluency = document.getElementById('fluency').value;
-      document.getElementById('create-session-btn').disabled = !(first && last && hearing && fluency);
+      const consentCode = document.getElementById('consent-code').value;
+      const consent = document.getElementById('consent-confirm').checked;
+      document.getElementById('create-session-btn').disabled = !(first && last && hearing && fluency && consentCode && consent);
     }
 
     // ----- Screens -----
@@ -466,7 +470,9 @@ function showScreen(screenId) {
       const email = document.getElementById('email').value.trim();
       const hearing = document.getElementById('hearing-status').value;
       const fluency = document.getElementById('fluency').value;
-      if (!first || !last || !hearing || !fluency) { alert('Please complete all fields'); return; }
+      const consentCode = document.getElementById('consent-code').value.trim();
+      const consent = document.getElementById('consent-confirm').checked;
+      if (!first || !last || !hearing || !fluency || !consentCode || !consent) { alert('Please complete all fields and confirm consent'); return; }
 
       if (isMobileDevice()) {
         const proceed = confirm(
@@ -483,6 +489,8 @@ function showScreen(screenId) {
       state.email = email;
       state.hearingStatus = hearing;
       state.fluency = fluency;
+      state.consentCode = consentCode;
+      state.consentConfirmed = consent;
 
       // Choose sequence (mobile vs desktop)
       const seed = Math.abs(hashCode(state.sessionCode));
@@ -507,6 +515,8 @@ function showScreen(screenId) {
         email: state.email,
         hearingStatus: state.hearingStatus,
         fluency: state.fluency,
+        consentCode: state.consentCode,
+        consentConfirmed: state.consentConfirmed,
         deviceType: state.isMobile ? 'mobile/tablet' : 'desktop',
         timestamp: new Date().toISOString()
       });


### PR DESCRIPTION
## Summary
- Ask new participants to confirm completing consent and provide their Qualtrics access code
- Require consent code and confirmation before starting a session and send values to the backend

## Testing
- `npm run lint`
- `npm run build`
- `npm start` *(fails: Missing configuration values: SHEETS_URL, CLOUDINARY_CLOUD_NAME, CLOUDINARY_UPLOAD_PRESET)*

------
https://chatgpt.com/codex/tasks/task_e_68b102ce84fc8326b90d1deb6bac30bd