### PR TITLE
Simplify recording with cross-browser support

### DIFF
--- a/google-apps-script.gs
+++ b/google-apps-script.gs
@@ -443,6 +443,8 @@ function createCorsOutput(data) {
   var output = ContentService.createTextOutput(JSON.stringify(data));
   output.setMimeType(ContentService.MimeType.JSON);
   output.setHeader('Access-Control-Allow-Origin', '*');
+  output.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  output.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
   return output;
 }
 

--- a/main.js
+++ b/main.js
@@ -1340,30 +1340,33 @@ Session code: ${state.sessionCode || ""}`);
     const preview = document.getElementById("video-preview");
     if (state.recording.stream) {
       preview.srcObject = state.recording.stream;
-      preview.style.display = "block";
-      preview.play().catch(() => {
+      preview.style.display = state.recording.isVideoMode ? "block" : "none";
+      if (state.recording.isVideoMode) preview.play().catch(() => {
       });
       return;
     }
     try {
-      const perm = await checkSecureAndPermissions();
-      if (perm.permissionsChecked && (perm.cam === "denied" || perm.mic === "denied")) {
-        const how = isIOS() ? "Settings \u2192 Safari \u2192 Camera/Microphone \u2192 Allow for this site, then reload." : "Click the camera icon in the address bar and allow camera and microphone, then reload.";
-        showRecordingError(`<strong>Camera or microphone is blocked</strong><p style="margin-top: 6px;">Please allow access for this site. ${how}</p>`);
-        return;
-      }
-      const stream = await navigator.mediaDevices.getUserMedia({
-        video: { width: 640, height: 480 },
-        audio: true
-      });
+      const stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
       state.recording.stream = stream;
       state.recording.isVideoMode = true;
       preview.srcObject = stream;
       preview.style.display = "block";
       preview.play().catch(() => {
       });
-    } catch (e) {
-      console.error("Preview failed:", e);
+    } catch (videoErr) {
+      console.warn("Video preview failed, trying audio-only", videoErr);
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        state.recording.stream = stream;
+        state.recording.isVideoMode = false;
+        preview.style.display = "none";
+        const status = document.getElementById("recording-status");
+        status.textContent = "\u{1F3A4} Audio ready to record";
+        status.className = "recording-status ready";
+      } catch (err) {
+        console.error("Audio preview failed", err);
+        showRecordingError('<strong>Camera or microphone not available</strong><p style="margin-top: 6px;">Please upload a recording instead.</p>');
+      }
     }
   }
   function updateRecordingImage() {
@@ -1428,40 +1431,6 @@ Session code: ${state.sessionCode || ""}`);
   `;
     }
     if (window.isSecureContext) startPreview();
-  }
-  function isIOS() {
-    return /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
-  }
-  async function checkSecureAndPermissions() {
-    if (!window.isSecureContext) {
-      const hint = location.protocol === "http:" ? "This page must be served over https." : "This page cannot run from a local file.";
-      throw { code: "NOT_SECURE", message: hint };
-    }
-    if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
-      throw { code: "NO_MEDIADEVICES", message: "This browser does not support in-page recording." };
-    }
-    if (!window.MediaRecorder) {
-      throw {
-        code: "NO_MEDIARECORDER",
-        message: "This browser does not support in-page recording."
-      };
-    }
-    let cam = "unknown", mic = "unknown";
-    let permissionsChecked = false;
-    if (navigator.permissions && navigator.permissions.query) {
-      try {
-        const camPerm = await navigator.permissions.query({ name: "camera" });
-        const micPerm = await navigator.permissions.query({ name: "microphone" });
-        cam = camPerm && camPerm.state || "unknown";
-        mic = micPerm && micPerm.state || "unknown";
-        permissionsChecked = true;
-      } catch (e) {
-        console.warn("Permission query failed:", e);
-      }
-    } else {
-      console.warn("Permissions API not available; skipping permission pre-check.");
-    }
-    return { cam, mic, permissionsChecked };
   }
   function showRecordingError(html, showFallback = true) {
     const box = document.getElementById("recording-error");
@@ -1545,220 +1514,61 @@ Session code: ${state.sessionCode || ""}`);
     const btn = document.getElementById("record-btn");
     const status = document.getElementById("recording-status");
     const preview = document.getElementById("video-preview");
-    if (!state.recording.active) {
-      try {
-        let stream = state.recording.stream;
-        let isVideoMode = state.recording.isVideoMode;
-        if (!stream) {
-          const perm = await checkSecureAndPermissions();
-          if (perm.permissionsChecked && (perm.cam === "denied" || perm.mic === "denied")) {
-            const how = isIOS() ? "Settings \u2192 Safari \u2192 Camera/Microphone \u2192 Allow for this site, then reload." : "Click the camera icon in the address bar and allow camera and microphone, then reload.";
-            showRecordingError(`<strong>Camera or microphone is blocked</strong><p style="margin-top: 6px;">Please allow access for this site. ${how}</p>`);
-            return;
-          } else if (!perm.permissionsChecked) {
-            console.warn("Permissions API unsupported; unable to pre-check camera/microphone permissions.");
-          }
-          try {
-            stream = await navigator.mediaDevices.getUserMedia({
-              video: { width: 640, height: 480 },
-              audio: true
-            });
-            isVideoMode = true;
-          } catch (videoError) {
-            console.warn("Video capture failed, trying audio-only:", videoError);
-            try {
-              stream = await navigator.mediaDevices.getUserMedia({
-                audio: true,
-                video: false
-              });
-              isVideoMode = false;
-              const audioNotice = document.createElement("div");
-              audioNotice.className = "info-box helpful";
-              audioNotice.innerHTML = `
-            <strong>\u{1F4E2} Audio-Only Mode</strong>
-            <p>Recording voice only (camera not available). This is fine for the task!</p>
-          `;
-              document.getElementById("recording-content").insertBefore(
-                audioNotice,
-                document.querySelector(".recording-controls")
-              );
-            } catch (audioError) {
-              console.error("Audio capture also failed:", audioError);
-              throw audioError;
-            }
-          }
-          state.recording.stream = stream;
-          state.recording.isVideoMode = isVideoMode;
-        }
-        if (isVideoMode) {
-          preview.srcObject = stream;
-          preview.style.display = "block";
-          preview.play().catch(() => {
-          });
-        } else {
+    if (!state.recording.mediaRecorder) {
+      if (!state.recording.stream) await startPreview();
+      if (!state.recording.stream) return;
+      let mimeType;
+      if (state.recording.isVideoMode) {
+        mimeType = MediaRecorder.isTypeSupported("video/webm;codecs=vp9") ? "video/webm;codecs=vp9" : MediaRecorder.isTypeSupported("video/webm;codecs=vp8") ? "video/webm;codecs=vp8" : "video/webm";
+      } else {
+        mimeType = MediaRecorder.isTypeSupported("audio/webm;codecs=opus") ? "audio/webm;codecs=opus" : "audio/webm";
+      }
+      state.recording.chunks = [];
+      state.recording.mediaRecorder = new MediaRecorder(state.recording.stream, { mimeType });
+      state.recording.mediaRecorder.ondataavailable = (e) => {
+        if (e.data && e.data.size > 0) state.recording.chunks.push(e.data);
+      };
+      state.recording.mediaRecorder.onstop = () => {
+        const blob = new Blob(state.recording.chunks, { type: mimeType });
+        state.recording.currentBlob = blob;
+        revokeRecordedURL();
+        const recordedEl = document.getElementById("recorded-video");
+        if (state.recording.isVideoMode) {
+          recordedEl.src = URL.createObjectURL(blob);
+          recordedEl.style.display = "block";
           preview.style.display = "none";
-          status.textContent = "\u{1F3A4} Audio ready to record";
-        }
-        if (!window.MediaRecorder) {
-          showRecordingError(`<strong>Recording not supported in this browser</strong><p style="margin-top: 6px;">Please record using your device's camera or voice recorder, then upload the file below.</p>`);
-          return;
-        }
-        let options = {};
-        let recordingFormat = "webm";
-        if (isVideoMode) {
-          const formatTests = [
-            { mime: "video/mp4;codecs=h264,aac", format: "mp4", ext: "mp4" },
-            { mime: "video/webm;codecs=vp9,opus", format: "webm-vp9", ext: "webm" },
-            { mime: "video/webm;codecs=vp8,opus", format: "webm-vp8", ext: "webm" },
-            { mime: "video/webm", format: "webm", ext: "webm" }
-          ];
-          for (const test of formatTests) {
-            if (MediaRecorder.isTypeSupported && MediaRecorder.isTypeSupported(test.mime)) {
-              options.mimeType = test.mime;
-              recordingFormat = test.ext;
-              console.log(`Recording format selected: ${test.format} (${test.mime})`);
-              break;
-            }
-          }
-          options.videoBitsPerSecond = 5e5;
-          options.audioBitsPerSecond = 64e3;
-          state.recording.recordingFormat = recordingFormat;
-          state.recording.recordingMimeType = options.mimeType || "video/webm";
         } else {
-          if (MediaRecorder.isTypeSupported && MediaRecorder.isTypeSupported("audio/webm;codecs=opus")) {
-            options.mimeType = "audio/webm;codecs=opus";
-          } else if (MediaRecorder.isTypeSupported && MediaRecorder.isTypeSupported("audio/ogg;codecs=opus")) {
-            options.mimeType = "audio/ogg;codecs=opus";
-          } else if (MediaRecorder.isTypeSupported && MediaRecorder.isTypeSupported("audio/mp4")) {
-            options.mimeType = "audio/mp4";
-          }
-          state.recording.recordingFormat = "webm";
-          state.recording.recordingMimeType = options.mimeType || "audio/webm";
+          const audioPlayer = document.createElement("audio");
+          audioPlayer.id = "recorded-audio";
+          audioPlayer.controls = true;
+          audioPlayer.src = URL.createObjectURL(blob);
+          const container = recordedEl.parentElement;
+          const existing = document.getElementById("recorded-audio");
+          if (existing) existing.remove();
+          container.insertBefore(audioPlayer, recordedEl);
+          recordedEl.style.display = "none";
         }
-        state.recording.mediaRecorder = new MediaRecorder(stream, options);
-        state.recording.chunks = [];
-        state.recording.mediaRecorder.ondataavailable = (e) => {
-          if (e.data && e.data.size > 0) state.recording.chunks.push(e.data);
-        };
-        state.recording.mediaRecorder.onstop = () => {
-          try {
-            revokeRecordedURL();
-            const mimeType = state.recording.recordingMimeType || (isVideoMode ? "video/webm" : "audio/webm");
-            const blob = new Blob(state.recording.chunks, { type: mimeType });
-            blob.recordingFormat = state.recording.recordingFormat || (isVideoMode ? "webm" : "webm");
-            blob.recordingMimeType = mimeType;
-            if (!isVideoMode) {
-              const audioPlayer = document.createElement("audio");
-              audioPlayer.id = "recorded-audio";
-              audioPlayer.controls = true;
-              audioPlayer.style.width = "100%";
-              audioPlayer.src = URL.createObjectURL(blob);
-              const container = document.getElementById("recorded-video").parentElement;
-              const existingAudio = document.getElementById("recorded-audio");
-              if (existingAudio) existingAudio.remove();
-              container.insertBefore(audioPlayer, document.getElementById("recorded-video"));
-              document.getElementById("recorded-video").style.display = "none";
-            } else {
-              const url = URL.createObjectURL(blob);
-              const recordedEl = document.getElementById("recorded-video");
-              recordedEl.src = url;
-              recordedEl.style.display = "block";
-              preview.style.display = "none";
-            }
-            document.getElementById("record-btn").style.display = "none";
-            document.getElementById("rerecord-btn").style.display = "inline-block";
-            document.getElementById("save-recording-btn").style.display = "inline-block";
-            const format = blob.recordingFormat === "mp4" ? "MP4" : isVideoMode ? "WebM" : "Audio";
-            const sizeKB = Math.round(blob.size / 1024);
-            const sizeMB = (blob.size / (1024 * 1024)).toFixed(1);
-            status.textContent = `Recording complete (${format}, ${sizeMB}MB)`;
-            status.className = "recording-status recorded";
-            if (blob.size > 25 * 1024 * 1024) {
-              const warningDiv = document.createElement("div");
-              warningDiv.className = "info-box warning";
-              warningDiv.innerHTML = `
-        <strong>\u26A0\uFE0F Large file warning</strong>
-        <p>Your recording is ${sizeMB}MB. Files over 25MB may fail to upload. Consider re-recording with a shorter description (30-45 seconds).</p>
-      `;
-              document.querySelector(".recording-controls").appendChild(warningDiv);
-            }
-            state.recording.currentBlob = blob;
-          } catch (e) {
-            console.error("Finalize error:", e);
-            alert("There was an issue finalizing the recording. Please try the upload option below.");
-          }
-        };
-        state.recording.mediaRecorder.start();
-        state.recording.active = true;
-        btn.textContent = "Stop Recording";
-        btn.className = "button danger";
-        status.textContent = isVideoMode ? "\u{1F534} Recording video..." : "\u{1F3A4} Recording audio...";
-        status.className = "recording-status recording";
-        startRecordingTimer();
-      } catch (err) {
-        console.error("Recording error:", err);
-        handleRecordingError(err);
-      }
-    } else {
-      try {
-        if (state.recording.mediaRecorder && state.recording.mediaRecorder.state !== "inactive") {
-          state.recording.mediaRecorder.stop();
-        }
-      } catch (e) {
-        console.warn("Stop error:", e);
-      } finally {
-        if (state.recording.stream) {
-          try {
-            state.recording.stream.getTracks().forEach((track) => track.stop());
-          } catch (e) {
-          }
-        }
-        state.recording.active = false;
-        btn.textContent = "Start Recording";
-        btn.className = "button danger";
-        stopRecordingTimer();
-      }
+        document.getElementById("record-btn").style.display = "none";
+        document.getElementById("rerecord-btn").style.display = "inline-block";
+        document.getElementById("save-recording-btn").style.display = "inline-block";
+        status.textContent = "\u2705 Recording complete! Ready to save.";
+        status.className = "recording-status recorded";
+        state.recording.mediaRecorder = null;
+      };
     }
-  }
-  function handleRecordingError(err) {
-    const name = err && (err.name || err.code) || "Unknown";
-    const errorMessages = {
-      "NOT_SECURE": {
-        title: "Secure connection required",
-        message: "This page must be served over HTTPS for recording to work.",
-        showUpload: true
-      },
-      "NotAllowedError": {
-        title: "Permission needed",
-        message: "Please allow camera and/or microphone access. If no prompt appeared, check your browser settings and refresh after granting permission.",
-        showUpload: true
-      },
-      "NotFoundError": {
-        title: "No recording device found",
-        message: "No camera or microphone detected. You can upload a recording instead.",
-        showUpload: true
-      },
-      "NotReadableError": {
-        title: "Device in use",
-        message: "Camera or microphone is being used by another application. Please close other apps and try again.",
-        showUpload: true
-      },
-      "NO_MEDIARECORDER": {
-        title: "Recording not supported",
-        message: "This browser cannot record directly. Use your device's camera or voice recorder and upload the file below.",
-        showUpload: true
-      }
-    };
-    const errorInfo = errorMessages[name] || {
-      title: "Recording not available",
-      message: `${err && err.message || "Recording failed"}. You can upload a file instead.`,
-      showUpload: true
-    };
-    showRecordingError(
-      `<strong>${errorInfo.title}</strong>
-     <p style="margin-top: 6px;">${errorInfo.message}</p>`,
-      errorInfo.showUpload
-    );
+    if (state.recording.mediaRecorder && state.recording.mediaRecorder.state === "recording") {
+      state.recording.mediaRecorder.stop();
+      btn.textContent = "Start Recording";
+      btn.className = "button danger";
+      stopRecordingTimer();
+    } else if (state.recording.mediaRecorder) {
+      state.recording.mediaRecorder.start();
+      startRecordingTimer();
+      btn.textContent = "Stop Recording";
+      btn.className = "button danger";
+      status.textContent = state.recording.isVideoMode ? "\u{1F534} Recording video..." : "\u{1F3A4} Recording audio...";
+      status.className = "recording-status recording";
+    }
   }
   function reRecord() {
     cleanupRecording(true).finally(() => updateRecordingImage());

--- a/src/main.js
+++ b/src/main.js
@@ -1007,30 +1007,31 @@ function openExternalTask(taskCode) {
       const preview = document.getElementById('video-preview');
       if (state.recording.stream) {
         preview.srcObject = state.recording.stream;
-        preview.style.display = 'block';
-        preview.play().catch(() => {});
+        preview.style.display = state.recording.isVideoMode ? 'block' : 'none';
+        if (state.recording.isVideoMode) preview.play().catch(() => {});
         return;
       }
       try {
-        const perm = await checkSecureAndPermissions();
-          if (perm.permissionsChecked && (perm.cam === 'denied' || perm.mic === 'denied')) {
-            const how = isIOS()
-              ? 'Settings \u2192 Safari \u2192 Camera/Microphone \u2192 Allow for this site, then reload.'
-              : 'Click the camera icon in the address bar and allow camera and microphone, then reload.';
-            showRecordingError(`<strong>Camera or microphone is blocked</strong><p style="margin-top: 6px;">Please allow access for this site. ${how}</p>`);
-            return;
-          }
-        const stream = await navigator.mediaDevices.getUserMedia({
-          video: { width: 640, height: 480 },
-          audio: true
-        });
+        const stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
         state.recording.stream = stream;
         state.recording.isVideoMode = true;
         preview.srcObject = stream;
         preview.style.display = 'block';
         preview.play().catch(() => {});
-      } catch (e) {
-        console.error('Preview failed:', e);
+      } catch (videoErr) {
+        console.warn('Video preview failed, trying audio-only', videoErr);
+        try {
+          const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+          state.recording.stream = stream;
+          state.recording.isVideoMode = false;
+          preview.style.display = 'none';
+          const status = document.getElementById('recording-status');
+          status.textContent = '🎤 Audio ready to record';
+          status.className = 'recording-status ready';
+        } catch (err) {
+          console.error('Audio preview failed', err);
+          showRecordingError('<strong>Camera or microphone not available</strong><p style="margin-top: 6px;">Please upload a recording instead.</p>');
+        }
       }
     }
 
@@ -1116,39 +1117,7 @@ if (instructionBox) {
       if (window.isSecureContext) startPreview();
     }
 
-    function isIOS() { return /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream; }
-
-    async function checkSecureAndPermissions() {
-      if (!window.isSecureContext) {
-        const hint = location.protocol === 'http:' ? 'This page must be served over https.' : 'This page cannot run from a local file.';
-        throw { code: 'NOT_SECURE', message: hint };
-      }
-      if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
-        throw { code: 'NO_MEDIADEVICES', message: 'This browser does not support in-page recording.' };
-      }
-      if (!window.MediaRecorder) {
-        throw {
-          code: 'NO_MEDIARECORDER',
-          message: 'This browser does not support in-page recording.'
-        };
-      }
-      let cam = 'unknown', mic = 'unknown';
-      let permissionsChecked = false;
-      if (navigator.permissions && navigator.permissions.query) {
-        try {
-          const camPerm = await navigator.permissions.query({ name: 'camera' });
-          const micPerm = await navigator.permissions.query({ name: 'microphone' });
-          cam = (camPerm && camPerm.state) || 'unknown';
-          mic = (micPerm && micPerm.state) || 'unknown';
-          permissionsChecked = true;
-        } catch (e) {
-          console.warn('Permission query failed:', e);
-        }
-      } else {
-        console.warn('Permissions API not available; skipping permission pre-check.');
-      }
-      return { cam, mic, permissionsChecked };
-    }
+    // Removed complex permission checks in favor of direct getUserMedia attempts for broader browser support
 
     function showRecordingError(html, showFallback = true) {
       const box = document.getElementById('recording-error');
@@ -1240,267 +1209,67 @@ function bindRecordingSkips() {
       if (btn1) btn1.addEventListener('click', () => showSkipDialog('ID'));
     }
 
+
     async function toggleRecording() {
       const btn = document.getElementById('record-btn');
       const status = document.getElementById('recording-status');
       const preview = document.getElementById('video-preview');
-
-      if (!state.recording.active) {
-        try {
-          let stream = state.recording.stream;
-          let isVideoMode = state.recording.isVideoMode;
-
-          if (!stream) {
-            // First check permissions
-            const perm = await checkSecureAndPermissions();
-              if (perm.permissionsChecked && (perm.cam === 'denied' || perm.mic === 'denied')) {
-                const how = isIOS()
-                  ? 'Settings \u2192 Safari \u2192 Camera/Microphone \u2192 Allow for this site, then reload.'
-                  : 'Click the camera icon in the address bar and allow camera and microphone, then reload.';
-                showRecordingError(`<strong>Camera or microphone is blocked</strong><p style="margin-top: 6px;">Please allow access for this site. ${how}</p>`);
-                return;
-              } else if (!perm.permissionsChecked) {
-              console.warn('Permissions API unsupported; unable to pre-check camera/microphone permissions.');
-            }
-
-            // Try video first, fall back to audio-only if needed
-            try {
-              stream = await navigator.mediaDevices.getUserMedia({
-                video: { width: 640, height: 480 },
-                audio: true
-              });
-              isVideoMode = true;
-            } catch (videoError) {
-              console.warn('Video capture failed, trying audio-only:', videoError);
-
-              try {
-                stream = await navigator.mediaDevices.getUserMedia({
-                  audio: true,
-                  video: false
-                });
-                isVideoMode = false;
-
-                const audioNotice = document.createElement('div');
-                audioNotice.className = 'info-box helpful';
-                audioNotice.innerHTML = `
-            <strong>📢 Audio-Only Mode</strong>
-            <p>Recording voice only (camera not available). This is fine for the task!</p>
-          `;
-                document.getElementById('recording-content').insertBefore(
-                  audioNotice,
-                  document.querySelector('.recording-controls')
-                );
-              } catch (audioError) {
-                console.error('Audio capture also failed:', audioError);
-                throw audioError;
-              }
-            }
-            state.recording.stream = stream;
-            state.recording.isVideoMode = isVideoMode;
-          }
-
-          if (isVideoMode) {
-            preview.srcObject = stream;
-            preview.style.display = 'block';
-            preview.play().catch(() => {});
-          } else {
+      if (!state.recording.mediaRecorder) {
+        if (!state.recording.stream) await startPreview();
+        if (!state.recording.stream) return;
+        let mimeType;
+        if (state.recording.isVideoMode) {
+          mimeType = MediaRecorder.isTypeSupported('video/webm;codecs=vp9') ? 'video/webm;codecs=vp9' :
+            MediaRecorder.isTypeSupported('video/webm;codecs=vp8') ? 'video/webm;codecs=vp8' : 'video/webm';
+        } else {
+          mimeType = MediaRecorder.isTypeSupported('audio/webm;codecs=opus') ? 'audio/webm;codecs=opus' : 'audio/webm';
+        }
+        state.recording.chunks = [];
+        state.recording.mediaRecorder = new MediaRecorder(state.recording.stream, { mimeType });
+        state.recording.mediaRecorder.ondataavailable = e => {
+          if (e.data && e.data.size > 0) state.recording.chunks.push(e.data);
+        };
+        state.recording.mediaRecorder.onstop = () => {
+          const blob = new Blob(state.recording.chunks, { type: mimeType });
+          state.recording.currentBlob = blob;
+          revokeRecordedURL();
+          const recordedEl = document.getElementById('recorded-video');
+          if (state.recording.isVideoMode) {
+            recordedEl.src = URL.createObjectURL(blob);
+            recordedEl.style.display = 'block';
             preview.style.display = 'none';
-            status.textContent = '🎤 Audio ready to record';
-          }
-
-          if (!window.MediaRecorder) {
-            showRecordingError(`<strong>Recording not supported in this browser</strong><p style="margin-top: 6px;">Please record using your device's camera or voice recorder, then upload the file below.</p>`);
-            return;
-          }
-
-          // Determine best format based on mode and browser support
-          // Detect best format with size optimization
-          let options = {};
-          let recordingFormat = 'webm'; // default
-
-          if (isVideoMode) {
-            const formatTests = [
-              { mime: 'video/mp4;codecs=h264,aac', format: 'mp4', ext: 'mp4' },
-              { mime: 'video/webm;codecs=vp9,opus', format: 'webm-vp9', ext: 'webm' },
-              { mime: 'video/webm;codecs=vp8,opus', format: 'webm-vp8', ext: 'webm' },
-              { mime: 'video/webm', format: 'webm', ext: 'webm' }
-            ];
-
-            for (const test of formatTests) {
-              if (MediaRecorder.isTypeSupported && MediaRecorder.isTypeSupported(test.mime)) {
-                options.mimeType = test.mime;
-                recordingFormat = test.ext;
-                console.log(`Recording format selected: ${test.format} (${test.mime})`);
-                break;
-              }
-            }
-
-            // Add bitrate limits to reduce file size (CRITICAL)
-            options.videoBitsPerSecond = 500000; // 500 kbps video
-            options.audioBitsPerSecond = 64000;  // 64 kbps audio
-
-            // Store format for later use
-            state.recording.recordingFormat = recordingFormat;
-            state.recording.recordingMimeType = options.mimeType || 'video/webm';
           } else {
-            // Audio-only formats
-            if (MediaRecorder.isTypeSupported && MediaRecorder.isTypeSupported('audio/webm;codecs=opus')) {
-              options.mimeType = 'audio/webm;codecs=opus';
-            } else if (MediaRecorder.isTypeSupported && MediaRecorder.isTypeSupported('audio/ogg;codecs=opus')) {
-              options.mimeType = 'audio/ogg;codecs=opus';
-            } else if (MediaRecorder.isTypeSupported && MediaRecorder.isTypeSupported('audio/mp4')) {
-              options.mimeType = 'audio/mp4';
-            }
-
-            // Store audio format info
-            state.recording.recordingFormat = 'webm';
-            state.recording.recordingMimeType = options.mimeType || 'audio/webm';
+            const audioPlayer = document.createElement('audio');
+            audioPlayer.id = 'recorded-audio';
+            audioPlayer.controls = true;
+            audioPlayer.src = URL.createObjectURL(blob);
+            const container = recordedEl.parentElement;
+            const existing = document.getElementById('recorded-audio');
+            if (existing) existing.remove();
+            container.insertBefore(audioPlayer, recordedEl);
+            recordedEl.style.display = 'none';
           }
-
-          state.recording.mediaRecorder = new MediaRecorder(stream, options);
-          state.recording.chunks = [];
-
-          state.recording.mediaRecorder.ondataavailable = e => {
-            if (e.data && e.data.size > 0) state.recording.chunks.push(e.data);
-          };
-
-          state.recording.mediaRecorder.onstop = () => {
-            try {
-              revokeRecordedURL();
-
-              const mimeType = state.recording.recordingMimeType || (isVideoMode ? 'video/webm' : 'audio/webm');
-              const blob = new Blob(state.recording.chunks, { type: mimeType });
-
-              // Attach format metadata to blob for upload
-              blob.recordingFormat = state.recording.recordingFormat || (isVideoMode ? 'webm' : 'webm');
-              blob.recordingMimeType = mimeType;
-
-              if (!isVideoMode) {
-                const audioPlayer = document.createElement('audio');
-                audioPlayer.id = 'recorded-audio';
-                audioPlayer.controls = true;
-                audioPlayer.style.width = '100%';
-                audioPlayer.src = URL.createObjectURL(blob);
-
-                const container = document.getElementById('recorded-video').parentElement;
-                const existingAudio = document.getElementById('recorded-audio');
-                if (existingAudio) existingAudio.remove();
-                container.insertBefore(audioPlayer, document.getElementById('recorded-video'));
-                document.getElementById('recorded-video').style.display = 'none';
-              } else {
-                const url = URL.createObjectURL(blob);
-                const recordedEl = document.getElementById('recorded-video');
-                recordedEl.src = url;
-                recordedEl.style.display = 'block';
-                preview.style.display = 'none';
-              }
-
-              document.getElementById('record-btn').style.display = 'none';
-              document.getElementById('rerecord-btn').style.display = 'inline-block';
-              document.getElementById('save-recording-btn').style.display = 'inline-block';
-
-              const format = blob.recordingFormat === 'mp4' ? 'MP4' : (isVideoMode ? 'WebM' : 'Audio');
-              const sizeKB = Math.round(blob.size / 1024);
-              const sizeMB = (blob.size / (1024 * 1024)).toFixed(1);
-
-              status.textContent = `Recording complete (${format}, ${sizeMB}MB)`;
-              status.className = 'recording-status recorded';
-
-              if (blob.size > 25 * 1024 * 1024) {
-                const warningDiv = document.createElement('div');
-                warningDiv.className = 'info-box warning';
-                warningDiv.innerHTML = `
-        <strong>⚠️ Large file warning</strong>
-        <p>Your recording is ${sizeMB}MB. Files over 25MB may fail to upload. Consider re-recording with a shorter description (30-45 seconds).</p>
-      `;
-                document.querySelector('.recording-controls').appendChild(warningDiv);
-              }
-
-              state.recording.currentBlob = blob;
-
-            } catch (e) {
-              console.error('Finalize error:', e);
-              alert('There was an issue finalizing the recording. Please try the upload option below.');
-            }
-          };
-
-          state.recording.mediaRecorder.start();
-          state.recording.active = true;
-          btn.textContent = 'Stop Recording';
-          btn.className = 'button danger';
-          status.textContent = isVideoMode ? '🔴 Recording video...' : '🎤 Recording audio...';
-          status.className = 'recording-status recording';
-          startRecordingTimer();
-
-        } catch (err) {
-          console.error('Recording error:', err);
-          handleRecordingError(err);
-        }
-      } else {
-        // Stop recording (existing code)
-        try {
-          if (state.recording.mediaRecorder && state.recording.mediaRecorder.state !== 'inactive') {
-            state.recording.mediaRecorder.stop();
-          }
-        } catch(e) {
-          console.warn('Stop error:', e);
-        } finally {
-          if (state.recording.stream) {
-            try {
-              state.recording.stream.getTracks().forEach(track => track.stop());
-            } catch(e) {}
-          }
-          state.recording.active = false;
-          btn.textContent = 'Start Recording';
-          btn.className = 'button danger';
-          stopRecordingTimer();
-        }
+          document.getElementById('record-btn').style.display = 'none';
+          document.getElementById('rerecord-btn').style.display = 'inline-block';
+          document.getElementById('save-recording-btn').style.display = 'inline-block';
+          status.textContent = '✅ Recording complete! Ready to save.';
+          status.className = 'recording-status recorded';
+          state.recording.mediaRecorder = null;
+        };
       }
-    }
-
-    function handleRecordingError(err) {
-      const name = (err && (err.name || err.code)) || 'Unknown';
-
-      // More helpful error messages
-      const errorMessages = {
-        'NOT_SECURE': {
-          title: 'Secure connection required',
-          message: 'This page must be served over HTTPS for recording to work.',
-          showUpload: true
-        },
-        'NotAllowedError': {
-          title: 'Permission needed',
-          message: 'Please allow camera and/or microphone access. If no prompt appeared, check your browser settings and refresh after granting permission.',
-          showUpload: true
-        },
-        'NotFoundError': {
-          title: 'No recording device found',
-          message: 'No camera or microphone detected. You can upload a recording instead.',
-          showUpload: true
-        },
-        'NotReadableError': {
-          title: 'Device in use',
-          message: 'Camera or microphone is being used by another application. Please close other apps and try again.',
-          showUpload: true
-        },
-        'NO_MEDIARECORDER': {
-          title: 'Recording not supported',
-          message: 'This browser cannot record directly. Use your device\'s camera or voice recorder and upload the file below.',
-          showUpload: true
-        }
-      };
-
-      const errorInfo = errorMessages[name] || {
-        title: 'Recording not available',
-        message: `${(err && err.message) || 'Recording failed'}. You can upload a file instead.`,
-        showUpload: true
-      };
-
-      showRecordingError(
-        `<strong>${errorInfo.title}</strong>
-     <p style="margin-top: 6px;">${errorInfo.message}</p>`,
-        errorInfo.showUpload
-      );
+      if (state.recording.mediaRecorder && state.recording.mediaRecorder.state === 'recording') {
+        state.recording.mediaRecorder.stop();
+        btn.textContent = 'Start Recording';
+        btn.className = 'button danger';
+        stopRecordingTimer();
+      } else if (state.recording.mediaRecorder) {
+        state.recording.mediaRecorder.start();
+        startRecordingTimer();
+        btn.textContent = 'Stop Recording';
+        btn.className = 'button danger';
+        status.textContent = state.recording.isVideoMode ? '🔴 Recording video...' : '🎤 Recording audio...';
+        status.className = 'recording-status recording';
+      }
     }
 
     function reRecord() { cleanupRecording(true).finally(() => updateRecordingImage()); }


### PR DESCRIPTION
## Summary
- Replace complex recorder with universal MediaRecorder implementation supporting video or audio
- Add automatic audio fallback and preview when camera access fails
- Remove obsolete permission checks for more robust browser compatibility
- Add explicit CORS headers in Apps Script endpoint to align with `no-cors` client requests

## Testing
- `npm run lint`
- `npm run lint -- google-apps-script.gs`
- `npm run build`
- `SHEETS_URL=https://example.com CLOUDINARY_CLOUD_NAME=test CLOUDINARY_UPLOAD_PRESET=test npm start`


------
https://chatgpt.com/codex/tasks/task_e_68b1046e71308326837fe829982570cb