### PR TITLE
Ensure video preview starts and restarts reliably

### DIFF
--- a/main.js
+++ b/main.js
@@ -1324,6 +1324,7 @@ Session code: ${state.sessionCode || ""}`);
       status.className = "recording-status warning";
     }
     showScreen("recording-screen");
+    if (window.isSecureContext) startPreview();
   }
   function revokeRecordedURL() {
     const recorded = document.getElementById("recorded-video");
@@ -1338,6 +1339,10 @@ Session code: ${state.sessionCode || ""}`);
   }
   async function startPreview() {
     const preview = document.getElementById("video-preview");
+    if (!preview) return;
+    preview.muted = true;
+    preview.playsInline = true;
+    preview.autoplay = true;
     if (state.recording.stream) {
       preview.srcObject = state.recording.stream;
       preview.style.display = state.recording.isVideoMode ? "block" : "none";
@@ -1430,7 +1435,6 @@ Session code: ${state.sessionCode || ""}`);
     </div>
   `;
     }
-    if (window.isSecureContext) startPreview();
   }
   function showRecordingError(html, showFallback = true) {
     const box = document.getElementById("recording-error");
@@ -1570,8 +1574,10 @@ Session code: ${state.sessionCode || ""}`);
       status.className = "recording-status recording";
     }
   }
-  function reRecord() {
-    cleanupRecording(true).finally(() => updateRecordingImage());
+  async function reRecord() {
+    await cleanupRecording(true);
+    updateRecordingImage();
+    if (window.isSecureContext) startPreview();
   }
   async function saveRecording() {
     if (!state.recording.currentBlob) {
@@ -1658,6 +1664,7 @@ Session code: ${state.sessionCode || ""}`);
           if (state.recording.currentImage === 0) {
             state.recording.currentImage = 1;
             updateRecordingImage();
+            if (window.isSecureContext) startPreview();
           } else {
             completeTask("ID");
           }
@@ -1712,6 +1719,7 @@ Session code: ${state.sessionCode || ""}`);
       if (state.recording.currentImage === 0) {
         state.recording.currentImage = 1;
         updateRecordingImage();
+        if (window.isSecureContext) startPreview();
       } else {
         completeTask("ID");
       }
@@ -1798,6 +1806,7 @@ Session code: ${state.sessionCode || ""}`);
       if (imageNumber === 1 && state.recording.currentImage === 0) {
         state.recording.currentImage = 1;
         updateRecordingImage();
+        if (window.isSecureContext) startPreview();
       } else {
         completeTask("ID");
       }

--- a/src/main.js
+++ b/src/main.js
@@ -992,6 +992,7 @@ function openExternalTask(taskCode) {
       }
 
       showScreen('recording-screen');
+      if (window.isSecureContext) startPreview();
     }
 
     function revokeRecordedURL() {
@@ -1005,6 +1006,10 @@ function openExternalTask(taskCode) {
 
     async function startPreview() {
       const preview = document.getElementById('video-preview');
+      if (!preview) return;
+      preview.muted = true;
+      preview.playsInline = true;
+      preview.autoplay = true;
       if (state.recording.stream) {
         preview.srcObject = state.recording.stream;
         preview.style.display = state.recording.isVideoMode ? 'block' : 'none';
@@ -1114,10 +1119,9 @@ if (instructionBox) {
   `;
 }
 
-      if (window.isSecureContext) startPreview();
-    }
+      }
 
-    // Removed complex permission checks in favor of direct getUserMedia attempts for broader browser support
+      // Removed complex permission checks in favor of direct getUserMedia attempts for broader browser support
 
     function showRecordingError(html, showFallback = true) {
       const box = document.getElementById('recording-error');
@@ -1272,7 +1276,11 @@ function bindRecordingSkips() {
       }
     }
 
-    function reRecord() { cleanupRecording(true).finally(() => updateRecordingImage()); }
+    async function reRecord() {
+      await cleanupRecording(true);
+      updateRecordingImage();
+      if (window.isSecureContext) startPreview();
+    }
 
     // Updated saveRecording function with Google Drive upload
 // Updated saveRecording function with enhanced logging
@@ -1377,11 +1385,12 @@ async function saveRecording() {
       uploadProgress.style.display = 'none';
 
       setTimeout(() => {
-        if (state.recording.currentImage === 0) { 
-          state.recording.currentImage = 1; 
-          updateRecordingImage(); 
-        } else { 
-          completeTask('ID'); 
+        if (state.recording.currentImage === 0) {
+          state.recording.currentImage = 1;
+          updateRecordingImage();
+          if (window.isSecureContext) startPreview();
+        } else {
+          completeTask('ID');
         }
       }, 1000);
 
@@ -1441,11 +1450,12 @@ function continueWithoutUpload() {
       mimeType: state.recording.currentBlob.type
     });
 
-    if (state.recording.currentImage === 0) { 
-      state.recording.currentImage = 1; 
-      updateRecordingImage(); 
-    } else { 
-      completeTask('ID'); 
+    if (state.recording.currentImage === 0) {
+      state.recording.currentImage = 1;
+      updateRecordingImage();
+      if (window.isSecureContext) startPreview();
+    } else {
+      completeTask('ID');
     }
     
     document.getElementById('recording-error').style.display = 'none';
@@ -1535,6 +1545,7 @@ function continueWithoutUpload() {
         if (imageNumber === 1 && state.recording.currentImage === 0) {
           state.recording.currentImage = 1;
           updateRecordingImage();
+          if (window.isSecureContext) startPreview();
         } else {
           completeTask('ID');
         }


### PR DESCRIPTION
## Summary
- Start the camera preview only after the recording screen is visible and when re-recording or switching images.
- Set video element playback properties for broader browser support.

## Testing
- `npm run lint`
- `npm run build`
- `npm start` *(fails: Missing configuration values: SHEETS_URL, CLOUDINARY_CLOUD_NAME, CLOUDINARY_UPLOAD_PRESET)*

------
https://chatgpt.com/codex/tasks/task_e_68b107a6c3788326a5716285231173ec