### PR TITLE
Add media recorder and Cloudinary upload

### DIFF
--- a/index.html
+++ b/index.html
@@ -775,6 +775,31 @@
   </div>
 </div>
 
+  <!-- === MS-RECORDER-HTML START === -->
+  <section id="recorder" class="recorder">
+    <h2>Recording task</h2>
+
+    <fieldset>
+      <legend>Mode</legend>
+      <label><input type="radio" name="rec-mode" value="video" checked> Video + audio</label>
+      <label><input type="radio" name="rec-mode" value="audio"> Audio only</label>
+    </fieldset>
+
+    <div class="rec-controls">
+      <button id="rec-start" type="button">Start recording</button>
+      <button id="rec-stop" type="button" disabled>Stop</button>
+      <button id="rec-upload" type="button" disabled>Upload</button>
+    </div>
+
+    <p id="rec-status" aria-live="polite">Idle</p>
+
+    <video id="rec-preview-video" playsinline controls style="max-width:480px; display:none;"></video>
+    <audio id="rec-preview-audio" controls style="width:480px; display:none;"></audio>
+
+    <progress id="rec-progress" value="0" max="100" style="width:480px; display:none;"></progress>
+  </section>
+  <!-- === MS-RECORDER-HTML END === -->
+
   <script src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -417,6 +417,10 @@
   }
 
   // src/main.js
+  var CLOUDINARY_CLOUD = "demo";
+  var CLOUDINARY_PRESET = "unsigned";
+  var CLOUDINARY_FOLDER = "spatial-cognition-videos";
+  var RECORDING_BYTES_LIMIT = 50 * 1024 * 1024;
   document.querySelectorAll(".support-email").forEach((el) => {
     el.textContent = CONFIG.SUPPORT_EMAIL;
     if (el.tagName === "A") el.href = `mailto:${CONFIG.SUPPORT_EMAIL}`;
@@ -729,6 +733,7 @@ Session code: ${state.sessionCode || ""}`);
   });
   function init() {
     setupEventListeners();
+    msRecorderInit();
     if (!window.isSecureContext) {
       const style = document.createElement("style");
       style.textContent = `#record-btn { display: none !important; }`;
@@ -2229,6 +2234,215 @@ Thank you!`);
       });
     } catch (error) {
       console.error("Error sending to sheets:", error);
+    }
+  }
+  function msRecorderInit() {
+    const $ = (s) => document.querySelector(s);
+    const btnStart = $("#rec-start");
+    const btnStop = $("#rec-stop");
+    const btnUpload = $("#rec-upload");
+    const statusEl = $("#rec-status");
+    const progressEl = $("#rec-progress");
+    const videoEl = $("#rec-preview-video");
+    const audioEl = $("#rec-preview-audio");
+    const modeInputs = Array.from(document.querySelectorAll('input[name="rec-mode"]'));
+    let mediaStream = null;
+    let mediaRecorder = null;
+    let chunks = [];
+    let recordedFile = null;
+    let chosenMime = "";
+    let currentMode = modeInputs.find((r) => r.checked)?.value || "video";
+    modeInputs.forEach((r) => r.addEventListener("change", () => {
+      currentMode = modeInputs.find((x) => x.checked)?.value || "video";
+      videoEl.style.display = "none";
+      audioEl.style.display = "none";
+      videoEl.src = "";
+      audioEl.src = "";
+      recordedFile = null;
+      btnUpload.disabled = true;
+      statusEl.textContent = `Mode set to ${currentMode === "audio" ? "Audio only" : "Video + audio"}`;
+    }));
+    function pickMime(mode) {
+      const ua = navigator.userAgent.toLowerCase();
+      const isSafari = ua.includes("safari") && !ua.includes("chrome");
+      const videoListSafariFirst = [
+        "video/mp4;codecs=avc1,mp4a",
+        "video/mp4",
+        "video/webm;codecs=vp9,opus",
+        "video/webm;codecs=vp8,opus",
+        "video/webm"
+      ];
+      const videoListChromeFirst = [
+        "video/webm;codecs=vp9,opus",
+        "video/webm;codecs=vp8,opus",
+        "video/webm",
+        "video/mp4;codecs=avc1,mp4a",
+        "video/mp4"
+      ];
+      const audioListSafariFirst = [
+        "audio/mp4;codecs=mp4a.40.2",
+        "audio/mp4",
+        "audio/webm;codecs=opus",
+        "audio/webm"
+      ];
+      const audioListChromeFirst = [
+        "audio/webm;codecs=opus",
+        "audio/webm",
+        "audio/mp4;codecs=mp4a.40.2",
+        "audio/mp4"
+      ];
+      const list = mode === "audio" ? isSafari ? audioListSafariFirst : audioListChromeFirst : isSafari ? videoListSafariFirst : videoListChromeFirst;
+      for (const t of list) {
+        if (window.MediaRecorder && MediaRecorder.isTypeSupported && MediaRecorder.isTypeSupported(t)) {
+          return t;
+        }
+      }
+      return "";
+    }
+    async function startRecording() {
+      try {
+        btnStart.disabled = true;
+        statusEl.textContent = "Requesting media...";
+        const constraints = currentMode === "audio" ? { audio: { echoCancellation: true, noiseSuppression: true }, video: false } : {
+          video: { width: { ideal: 1280 }, height: { ideal: 720 }, facingMode: "user" },
+          audio: { echoCancellation: true, noiseSuppression: true }
+        };
+        chosenMime = pickMime(currentMode);
+        mediaStream = await navigator.mediaDevices.getUserMedia(constraints);
+        chunks = [];
+        mediaRecorder = chosenMime ? new MediaRecorder(mediaStream, { mimeType: chosenMime }) : new MediaRecorder(mediaStream);
+        mediaRecorder.ondataavailable = (e) => {
+          if (e.data && e.data.size) chunks.push(e.data);
+        };
+        mediaRecorder.onstart = () => {
+          statusEl.textContent = `Recording... ${chosenMime || "(default)"}`;
+        };
+        mediaRecorder.onstop = handleStop;
+        mediaRecorder.start();
+        btnStop.disabled = false;
+      } catch (err) {
+        console.error(err);
+        statusEl.textContent = "Failed to start recording. Check camera and mic permissions.";
+        btnStart.disabled = false;
+      }
+    }
+    function stopRecording() {
+      try {
+        if (mediaRecorder && mediaRecorder.state === "recording") {
+          mediaRecorder.stop();
+        }
+      } catch (e) {
+        console.error(e);
+        handleStop();
+      }
+    }
+    function cleanupStream() {
+      if (mediaStream) {
+        mediaStream.getTracks().forEach((t) => t.stop());
+        mediaStream = null;
+      }
+    }
+    function handleStop() {
+      try {
+        const isAudio = currentMode === "audio";
+        const type = chosenMime || (isAudio ? "audio/webm" : "video/webm");
+        let ext = "webm";
+        if (type.includes("mp4")) ext = isAudio ? "m4a" : "mp4";
+        const blob = new Blob(chunks, { type });
+        if (blob.size > RECORDING_BYTES_LIMIT) {
+          statusEl.textContent = `Recording is ${Math.round(blob.size / 1024 / 1024)} MB, over limit of ${Math.round(RECORDING_BYTES_LIMIT / 1024 / 1024)} MB. Please record a shorter clip.`;
+          recordedFile = null;
+          btnUpload.disabled = true;
+          return;
+        }
+        recordedFile = new File([blob], `study-recording.${ext}`, { type });
+        if (isAudio) {
+          audioEl.src = URL.createObjectURL(recordedFile);
+          audioEl.style.display = "";
+          videoEl.style.display = "none";
+        } else {
+          videoEl.src = URL.createObjectURL(recordedFile);
+          try {
+            videoEl.src += "#t=0.001";
+          } catch {
+          }
+          videoEl.style.display = "";
+          audioEl.style.display = "none";
+        }
+        statusEl.textContent = `Ready to upload, ${Math.round(recordedFile.size / 1024 / 1024)} MB`;
+        btnUpload.disabled = false;
+      } catch (err) {
+        console.error(err);
+        statusEl.textContent = "Error finalizing recording.";
+      } finally {
+        btnStop.disabled = true;
+        btnStart.disabled = false;
+        cleanupStream();
+      }
+    }
+    function uploadToCloudinary2(file) {
+      return new Promise((resolve, reject) => {
+        const url = `https://api.cloudinary.com/v1_1/${CLOUDINARY_CLOUD}/video/upload`;
+        const form = new FormData();
+        form.append("file", file, file.name);
+        form.append("upload_preset", CLOUDINARY_PRESET);
+        form.append("folder", CLOUDINARY_FOLDER);
+        const xhr = new XMLHttpRequest();
+        xhr.open("POST", url);
+        xhr.upload.onprogress = (e) => {
+          if (e.lengthComputable) {
+            const pct = Math.round(e.loaded / e.total * 100);
+            progressEl.style.display = "";
+            progressEl.value = pct;
+            statusEl.textContent = `Uploading... ${pct}%`;
+          }
+        };
+        xhr.onreadystatechange = () => {
+          if (xhr.readyState === 4) {
+            progressEl.style.display = "none";
+            if (xhr.status >= 200 && xhr.status < 300) {
+              try {
+                const res = JSON.parse(xhr.responseText);
+                statusEl.textContent = "Upload complete";
+                resolve(res);
+              } catch (err) {
+                statusEl.textContent = "Upload complete, parse error";
+                resolve({ raw: xhr.responseText });
+              }
+            } else {
+              statusEl.textContent = `Upload failed, status ${xhr.status}`;
+              reject(new Error(xhr.responseText || `HTTP ${xhr.status}`));
+            }
+          }
+        };
+        xhr.onerror = () => {
+          progressEl.style.display = "none";
+          statusEl.textContent = "Network error during upload";
+          reject(new Error("Network error"));
+        };
+        xhr.send(form);
+      });
+    }
+    btnStart.addEventListener("click", startRecording);
+    btnStop.addEventListener("click", stopRecording);
+    btnUpload.addEventListener("click", async () => {
+      if (!recordedFile) return;
+      btnUpload.disabled = true;
+      try {
+        const res = await uploadToCloudinary2(recordedFile);
+        console.log("Cloudinary response", res);
+        statusEl.textContent = "Uploaded successfully";
+      } catch (e) {
+        console.error(e);
+        statusEl.textContent = "Upload error. Please try again.";
+        btnUpload.disabled = false;
+      }
+    });
+    if (!window.MediaRecorder) {
+      statusEl.textContent = "MediaRecorder not supported in this browser.";
+      btnStart.disabled = true;
+      btnStop.disabled = true;
+      btnUpload.disabled = true;
     }
   }
   window.addEventListener("beforeunload", () => {


### PR DESCRIPTION
## Summary
- add recorder UI for video or audio capture with preview and progress
- integrate runtime MIME selection and Cloudinary upload utilities
- expose recorder initialization during app startup

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b109c8a864832683810405451623b6