### PR TITLE
refactor: modularize recording utilities

### DIFF
--- a/main.js
+++ b/main.js
@@ -416,6 +416,550 @@
     }
   }
 
+  // src/recorder.js
+  function revokeRecordedURL() {
+    const recorded = document.getElementById("recorded-video");
+    if (recorded && recorded.src) {
+      try {
+        URL.revokeObjectURL(recorded.src);
+      } catch (e) {
+      }
+      recorded.removeAttribute("src");
+      if (recorded.load) recorded.load();
+    }
+  }
+  async function startPreview(state2) {
+    const preview = document.getElementById("video-preview");
+    if (!preview) return;
+    preview.muted = true;
+    preview.playsInline = true;
+    preview.autoplay = true;
+    if (state2.recording.stream) {
+      preview.srcObject = state2.recording.stream;
+      preview.style.display = state2.recording.isVideoMode ? "block" : "none";
+      if (state2.recording.isVideoMode) preview.play().catch(() => {
+      });
+      return;
+    }
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+      state2.recording.stream = stream;
+      state2.recording.isVideoMode = true;
+      preview.srcObject = stream;
+      preview.style.display = "block";
+      preview.play().catch(() => {
+      });
+    } catch (videoErr) {
+      console.warn("Video preview failed, trying audio-only", videoErr);
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        state2.recording.stream = stream;
+        state2.recording.isVideoMode = false;
+        preview.style.display = "none";
+        const status = document.getElementById("recording-status");
+        status.textContent = "\u{1F3A4} Audio ready to record";
+        status.className = "recording-status ready";
+      } catch (err) {
+        console.error("Audio preview failed", err);
+        showRecordingError('<strong>Camera or microphone not available</strong><p style="margin-top: 6px;">Please upload a recording instead.</p>');
+      }
+    }
+  }
+  function updateRecordingImage(state2) {
+    const imageNum = state2.recording.currentImage + 1;
+    document.getElementById("image-number").textContent = imageNum;
+    document.getElementById("current-image").src = imageNum === 1 ? CONFIG.IMAGE_1 : CONFIG.IMAGE_2;
+    const preview = document.getElementById("video-preview");
+    const recorded = document.getElementById("recorded-video");
+    preview.style.display = "none";
+    recorded.style.display = "none";
+    revokeRecordedURL();
+    state2.recording.currentBlob = null;
+    document.getElementById("record-btn").style.display = "inline-block";
+    document.getElementById("rerecord-btn").style.display = "none";
+    document.getElementById("save-recording-btn").style.display = "none";
+    const status = document.getElementById("recording-status");
+    status.textContent = "Ready to record";
+    status.className = "recording-status ready";
+    document.getElementById("recording-error").style.display = "none";
+    document.getElementById("video-upload-fallback").style.display = "none";
+    document.getElementById("upload-progress").style.display = "none";
+    const fileInput = document.getElementById("video-file-input");
+    if (fileInput) fileInput.value = "";
+    const uploadBtn = document.getElementById("upload-save-btn");
+    if (uploadBtn) {
+      uploadBtn.style.display = "none";
+      uploadBtn.textContent = "Use this upload";
+    }
+    const recordingInstructions = document.createElement("div");
+    recordingInstructions.className = "info-box important";
+    recordingInstructions.id = "recording-size-warning";
+    recordingInstructions.innerHTML = `
+  <strong>\u{1F4F9} Recording Guidelines</strong>
+  <ul style="margin: 8px 0 0 20px; text-align: left;">
+    <li><strong>Duration:</strong> Keep recordings between 30-60 seconds</li>
+    <li><strong>File size:</strong> Recordings over 45 seconds may fail to upload</li>
+    <li><strong>Language:</strong> Use ASL if you know it, otherwise spoken English</li>
+    <li><strong>Can't record?</strong> Use the "Upload a Recording" option below</li>
+  </ul>
+`;
+    const recordingContent = document.getElementById("recording-content");
+    const recordingControls = recordingContent ? recordingContent.querySelector(".recording-controls") : null;
+    if (recordingControls && recordingControls.parentNode && !document.getElementById("recording-size-warning")) {
+      recordingControls.parentNode.insertBefore(recordingInstructions, recordingControls);
+    }
+    const requiredTextRec = "This task is required for study completion.";
+    const etaRec = TASKS["ID"] && TASKS["ID"].estMinutes ? `${TASKS["ID"].estMinutes} minutes` : "a few minutes";
+    const reqsRec = TASKS["ID"] && TASKS["ID"].requirements || "\u2014";
+    const instructionBox = document.getElementById("task-instructions");
+    if (instructionBox) {
+      document.getElementById("task-title").textContent = TASKS["ID"].name;
+      instructionBox.innerHTML = `
+      <div class="info-box friendly-tip" style="margin-bottom:10px;">
+        <strong>\u26A0\uFE0F Ready to Start ${TASKS["ID"].name}?</strong>
+        <ul style="margin:8px 0 0 20px; text-align:left;">
+          <li>${requiredTextRec}</li>
+          <li>Having problems? Email us instead of skipping</li>
+          <li>Estimated time: <strong>${etaRec}</strong></li>
+          <li>Requirements/tips: <em>${reqsRec}</em></li>
+        </ul>
+      </div>
+    `;
+    }
+  }
+  function showRecordingError(html, showFallback = true) {
+    const box = document.getElementById("recording-error");
+    if (!box) return;
+    box.style.display = "block";
+    box.innerHTML = html;
+    if (showFallback) {
+      const fb = document.getElementById("video-upload-fallback");
+      if (fb) fb.style.display = "block";
+    }
+  }
+  function enhanceUploadFallback(state2, saveRecordingFn) {
+    const fallbackDiv = document.getElementById("video-upload-fallback");
+    if (fallbackDiv) {
+      fallbackDiv.innerHTML = `
+    <h3>\u{1F4C1} Upload a Recording Instead</h3>
+    <div class="info-box helpful" style="margin: 15px 0;">
+      <strong>Upload Instructions:</strong>
+      <ol style="margin: 8px 0 0 20px; text-align: left;">
+        <li>Record a 30-60 second video/audio on your device</li>
+        <li>Accepted formats: MP4, MOV, WebM (video) or MP3, M4A, WAV (audio)</li>
+        <li>Maximum size: 50MB for MP4/MOV, 40MB for WebM, 25MB for audio</li>
+        <li>Select your file below</li>
+      </ol>
+    </div>
+    <input type="file"
+           id="video-file-input"
+           accept="video/mp4,video/quicktime,video/webm,video/*,audio/mp3,audio/mpeg,audio/m4a,audio/wav,audio/*,.mp4,.mov,.webm,.mp3,.m4a,.wav"
+           style="margin: 15px 0; padding: 10px; border: 2px solid var(--gray-300); border-radius: 8px; width: 100%;" />
+    <div id="file-info" style="margin: 10px 0; font-weight: bold;"></div>
+    <div class="button-group">
+      <button class="button success" id="upload-save-btn" style="display:none;">Upload This File</button>
+    </div>
+    <p style="font-size: 14px; color: var(--text-secondary); margin-top: 10px;">
+      \u{1F4A1} Tips: Use Camera app for video (iPhone/Android) or Voice Memos for audio (iPhone) or Voice Recorder (Android)
+    </p>
+  `;
+    }
+    bindUploadFallback(state2, saveRecordingFn);
+  }
+  function bindUploadFallback(state2, saveRecordingFn) {
+    const input = document.getElementById("video-file-input");
+    const btn = document.getElementById("upload-save-btn");
+    const info = document.getElementById("file-info");
+    if (!input || !btn || !info) return;
+    input.addEventListener("change", () => {
+      const f = input.files && input.files[0];
+      if (!f) return;
+      if (!f.type.startsWith("video/") && !f.type.startsWith("audio/")) {
+        alert("Please select a video or audio file");
+        input.value = "";
+        info.textContent = "";
+        btn.style.display = "none";
+        return;
+      }
+      let format = "audio";
+      if (f.type.includes("mp4") || f.name.toLowerCase().endsWith(".mp4")) format = "mp4";
+      else if (f.type.includes("quicktime") || f.name.toLowerCase().endsWith(".mov")) format = "mov";
+      else if (f.type.includes("webm") || f.name.toLowerCase().endsWith(".webm")) format = "webm";
+      else if (f.type.startsWith("video/")) format = "other-video";
+      const sizeLimits = { mp4: 50, mov: 50, webm: 40, "other-video": 40, audio: 25 };
+      const maxMB = sizeLimits[format];
+      const sizeMB = f.size / (1024 * 1024);
+      if (sizeMB > maxMB) {
+        alert(`File too large: ${sizeMB.toFixed(1)}MB. Maximum for ${format.toUpperCase()} is ${maxMB}MB.`);
+        input.value = "";
+        info.textContent = "";
+        btn.style.display = "none";
+        return;
+      }
+      state2.recording.currentBlob = f;
+      info.textContent = `${f.name} (${sizeMB.toFixed(1)}MB)`;
+      btn.style.display = "inline-block";
+    });
+    btn.addEventListener("click", saveRecordingFn);
+  }
+  function bindRecordingSkips(showSkipDialog2) {
+    const btn1 = document.getElementById("skip-recording-btn");
+    if (btn1) btn1.addEventListener("click", () => showSkipDialog2("ID"));
+  }
+  function startRecordingTimer(state2) {
+    const timer = document.getElementById("recording-timer");
+    timer.style.display = "block";
+    let seconds = 0;
+    state2.recording.recordingStart = Date.now();
+    state2.recording._timer = setInterval(() => {
+      seconds++;
+      const mins = Math.floor(seconds / 60);
+      const secs = seconds % 60;
+      timer.textContent = `${mins.toString().padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
+    }, 1e3);
+  }
+  function stopRecordingTimer2(state2) {
+    clearInterval(state2.recording._timer);
+    const t = document.getElementById("recording-timer");
+    if (t) t.style.display = "none";
+    if (state2.recording.recordingStart) {
+      state2.recording.recordingDuration = Date.now() - state2.recording.recordingStart;
+    }
+  }
+  async function toggleRecording(state2) {
+    const btn = document.getElementById("record-btn");
+    const status = document.getElementById("recording-status");
+    const preview = document.getElementById("video-preview");
+    if (!state2.recording.mediaRecorder) {
+      if (!state2.recording.stream) await startPreview(state2);
+      if (!state2.recording.stream) return;
+      let mimeType;
+      if (state2.recording.isVideoMode) {
+        mimeType = MediaRecorder.isTypeSupported("video/webm;codecs=vp9") ? "video/webm;codecs=vp9" : MediaRecorder.isTypeSupported("video/webm;codecs=vp8") ? "video/webm;codecs=vp8" : "video/webm";
+      } else {
+        mimeType = MediaRecorder.isTypeSupported("audio/webm;codecs=opus") ? "audio/webm;codecs=opus" : "audio/webm";
+      }
+      state2.recording.chunks = [];
+      state2.recording.mediaRecorder = new MediaRecorder(state2.recording.stream, { mimeType });
+      state2.recording.mediaRecorder.ondataavailable = (e) => {
+        if (e.data && e.data.size > 0) state2.recording.chunks.push(e.data);
+      };
+      state2.recording.mediaRecorder.onstop = () => {
+        const blob = new Blob(state2.recording.chunks, { type: mimeType });
+        state2.recording.currentBlob = blob;
+        revokeRecordedURL();
+        const recordedEl = document.getElementById("recorded-video");
+        if (state2.recording.isVideoMode) {
+          recordedEl.src = URL.createObjectURL(blob);
+          recordedEl.style.display = "block";
+          preview.style.display = "none";
+        } else {
+          const audioPlayer = document.createElement("audio");
+          audioPlayer.id = "recorded-audio";
+          audioPlayer.controls = true;
+          audioPlayer.src = URL.createObjectURL(blob);
+          const container = recordedEl.parentElement;
+          const existing = document.getElementById("recorded-audio");
+          if (existing) existing.remove();
+          container.insertBefore(audioPlayer, recordedEl);
+          recordedEl.style.display = "none";
+        }
+        document.getElementById("record-btn").style.display = "none";
+        document.getElementById("rerecord-btn").style.display = "inline-block";
+        document.getElementById("save-recording-btn").style.display = "inline-block";
+        status.textContent = "\u2705 Recording complete! Ready to save.";
+        status.className = "recording-status recorded";
+        state2.recording.mediaRecorder = null;
+      };
+    }
+    if (state2.recording.mediaRecorder && state2.recording.mediaRecorder.state === "recording") {
+      state2.recording.mediaRecorder.stop();
+      btn.textContent = "Start Recording";
+      btn.className = "button danger";
+      stopRecordingTimer2(state2);
+    } else if (state2.recording.mediaRecorder) {
+      state2.recording.mediaRecorder.start();
+      startRecordingTimer(state2);
+      btn.textContent = "Stop Recording";
+      btn.className = "button danger";
+      status.textContent = state2.recording.isVideoMode ? "\u{1F534} Recording video..." : "\u{1F3A4} Recording audio...";
+      status.className = "recording-status recording";
+    }
+  }
+  async function reRecord(state2) {
+    await cleanupRecording(state2, true);
+    updateRecordingImage(state2);
+    if (window.isSecureContext) startPreview(state2);
+  }
+  async function saveRecording(state2, sendToSheets2, completeTask2) {
+    if (!state2.recording.currentBlob) {
+      alert("Please record or upload a recording first.");
+      return;
+    }
+    const saveBtn = document.getElementById("save-recording-btn");
+    const originalText = saveBtn.textContent;
+    saveBtn.disabled = true;
+    saveBtn.textContent = "Processing...";
+    const status = document.getElementById("recording-status");
+    status.textContent = "\u2699\uFE0F Processing recording...";
+    status.className = "recording-status recording";
+    const uploadProgress = document.getElementById("upload-progress");
+    uploadProgress.style.display = "block";
+    const recType = state2.recording.isVideoMode ? "video" : state2.recording.currentBlob && state2.recording.currentBlob.type && state2.recording.currentBlob.type.startsWith("audio") ? "audio" : "video";
+    sendToSheets2({
+      action: "image_recorded",
+      sessionCode: state2.sessionCode,
+      imageNumber: state2.recording.currentImage + 1,
+      timestamp: (/* @__PURE__ */ new Date()).toISOString(),
+      recordingType: recType
+    });
+    sendToSheets2({
+      action: "video_recorded",
+      sessionCode: state2.sessionCode,
+      imageNumber: state2.recording.currentImage + 1,
+      timestamp: (/* @__PURE__ */ new Date()).toISOString(),
+      recordingType: recType
+    });
+    try {
+      const uploadResult = await uploadVideoToDrive(
+        state2.recording.currentBlob,
+        state2.sessionCode,
+        state2.recording.currentImage + 1,
+        sendToSheets2
+      );
+      if (uploadResult.success) {
+        state2.recording.recordings.push({
+          image: state2.recording.currentImage + 1,
+          blob: state2.recording.currentBlob,
+          timestamp: (/* @__PURE__ */ new Date()).toISOString(),
+          driveFileId: uploadResult.fileId,
+          driveFileUrl: uploadResult.fileUrl,
+          filename: uploadResult.filename,
+          uploadMethod: uploadResult.uploadMethod,
+          recordingType: state2.recording.isVideoMode ? "video" : "audio",
+          mimeType: state2.recording.currentBlob.type
+        });
+        const logData = {
+          action: "image_recorded_and_uploaded",
+          sessionCode: state2.sessionCode,
+          imageNumber: state2.recording.currentImage + 1,
+          driveFileId: uploadResult.fileId,
+          filename: uploadResult.filename,
+          timestamp: (/* @__PURE__ */ new Date()).toISOString(),
+          deviceType: state2.isMobile ? "mobile/tablet" : "desktop",
+          uploadMethod: uploadResult.uploadMethod,
+          fileSize: Math.round(state2.recording.currentBlob.size / 1024),
+          uploadStatus: "success",
+          recordingType: state2.recording.isVideoMode ? "video" : "audio",
+          mimeType: state2.recording.currentBlob.type
+        };
+        sendToSheets2(logData);
+        sendToSheets2({
+          action: "log_video_upload",
+          sessionCode: state2.sessionCode,
+          imageNumber: state2.recording.currentImage + 1,
+          filename: uploadResult.filename,
+          fileId: uploadResult.fileId,
+          fileUrl: uploadResult.fileUrl,
+          fileSize: Math.round(state2.recording.currentBlob.size / 1024),
+          uploadTime: (/* @__PURE__ */ new Date()).toISOString(),
+          uploadMethod: uploadResult.uploadMethod,
+          uploadStatus: "success",
+          recordingType: state2.recording.isVideoMode ? "video" : "audio",
+          mimeType: state2.recording.currentBlob.type
+        });
+        status.textContent = `\u2705 Upload complete via ${uploadResult.uploadMethod}!`;
+        status.className = "recording-status recorded";
+        uploadProgress.style.display = "none";
+        setTimeout(() => {
+          if (state2.recording.currentImage === 0) {
+            state2.recording.currentImage = 1;
+            updateRecordingImage(state2);
+            if (window.isSecureContext) startPreview(state2);
+          } else {
+            completeTask2("ID");
+          }
+        }, 1e3);
+      } else {
+        throw new Error(uploadResult.error || "Upload failed");
+      }
+    } catch (error) {
+      console.error("Upload error:", error);
+      sendToSheets2({
+        action: "log_video_upload_error",
+        sessionCode: state2.sessionCode,
+        imageNumber: state2.recording.currentImage + 1,
+        error: error.message,
+        timestamp: (/* @__PURE__ */ new Date()).toISOString(),
+        deviceType: state2.isMobile ? "mobile/tablet" : "desktop",
+        attemptedMethod: "drive",
+        recordingType: state2.recording.isVideoMode ? "video" : "audio",
+        mimeType: state2.recording.currentBlob.type
+      });
+      status.textContent = "\u26A0\uFE0F Upload failed. Retrying...";
+      status.className = "recording-status recording";
+      enqueueFailedUpload(state2, state2.recording.currentBlob, state2.sessionCode, state2.recording.currentImage + 1, sendToSheets2, completeTask2);
+    } finally {
+      saveBtn.disabled = false;
+      saveBtn.textContent = originalText;
+    }
+  }
+  async function retryVideoUpload(state2, sendToSheets2, completeTask2) {
+    document.getElementById("recording-error").style.display = "none";
+    await saveRecording(state2, sendToSheets2, completeTask2);
+  }
+  function enqueueFailedUpload(state2, blob, sessionCode, imageNumber, sendToSheets2, completeTask2) {
+    state2.uploadQueue.push({ blob, sessionCode, imageNumber, attempts: 0 });
+    processUploadQueue(state2, sendToSheets2, completeTask2);
+  }
+  async function processUploadQueue(state2, sendToSheets2, completeTask2) {
+    if (state2.processingUpload || state2.uploadQueue.length === 0) return;
+    state2.processingUpload = true;
+    const item = state2.uploadQueue[0];
+    try {
+      const uploadResult = await uploadVideoToDrive(item.blob, item.sessionCode, item.imageNumber, sendToSheets2);
+      if (uploadResult.success) {
+        handleUploadSuccess(state2, uploadResult, item.imageNumber, item.blob, sendToSheets2, completeTask2);
+        state2.uploadQueue.shift();
+      } else {
+        throw new Error(uploadResult.error || "Upload failed");
+      }
+    } catch (err) {
+      item.attempts++;
+      if (item.attempts < 3) {
+        setTimeout(() => {
+          state2.processingUpload = false;
+          processUploadQueue(state2, sendToSheets2, completeTask2);
+        }, 5e3 * item.attempts);
+        return;
+      }
+      state2.uploadQueue.shift();
+      showUploadError(state2, err, item.imageNumber, item.blob, sendToSheets2);
+    }
+    state2.processingUpload = false;
+    if (state2.uploadQueue.length > 0) processUploadQueue(state2, sendToSheets2, completeTask2);
+  }
+  function handleUploadSuccess(state2, uploadResult, imageNumber, blob, sendToSheets2, completeTask2) {
+    state2.recording.recordings.push({
+      image: imageNumber,
+      blob,
+      timestamp: (/* @__PURE__ */ new Date()).toISOString(),
+      driveFileId: uploadResult.fileId,
+      driveFileUrl: uploadResult.fileUrl,
+      filename: uploadResult.filename,
+      uploadMethod: uploadResult.uploadMethod,
+      recordingType: state2.recording.isVideoMode ? "video" : "audio",
+      mimeType: blob.type
+    });
+    const logData = {
+      action: "image_recorded_and_uploaded",
+      sessionCode: state2.sessionCode,
+      imageNumber,
+      driveFileId: uploadResult.fileId,
+      filename: uploadResult.filename,
+      timestamp: (/* @__PURE__ */ new Date()).toISOString(),
+      deviceType: state2.isMobile ? "mobile/tablet" : "desktop",
+      uploadMethod: uploadResult.uploadMethod,
+      fileSize: Math.round(blob.size / 1024),
+      uploadStatus: "success",
+      recordingType: state2.recording.isVideoMode ? "video" : "audio",
+      mimeType: blob.type
+    };
+    sendToSheets2(logData);
+    sendToSheets2({
+      action: "log_video_upload",
+      sessionCode: state2.sessionCode,
+      imageNumber,
+      filename: uploadResult.filename,
+      fileId: uploadResult.fileId,
+      fileUrl: uploadResult.fileUrl,
+      fileSize: Math.round(blob.size / 1024),
+      uploadTime: (/* @__PURE__ */ new Date()).toISOString(),
+      uploadMethod: uploadResult.uploadMethod,
+      uploadStatus: "success",
+      recordingType: state2.recording.isVideoMode ? "video" : "audio",
+      mimeType: blob.type
+    });
+    const status = document.getElementById("recording-status");
+    status.textContent = `\u2705 Upload complete via ${uploadResult.uploadMethod}!`;
+    status.className = "recording-status recorded";
+    document.getElementById("upload-progress").style.display = "none";
+    setTimeout(() => {
+      if (imageNumber === 1 && state2.recording.currentImage === 0) {
+        state2.recording.currentImage = 1;
+        updateRecordingImage(state2);
+        if (window.isSecureContext) startPreview(state2);
+      } else {
+        completeTask2("ID");
+      }
+    }, 1e3);
+  }
+  function showUploadError(state2, error, imageNumber, blob, sendToSheets2) {
+    sendToSheets2({
+      action: "log_video_upload_error",
+      sessionCode: state2.sessionCode,
+      imageNumber,
+      error: error.message,
+      timestamp: (/* @__PURE__ */ new Date()).toISOString(),
+      deviceType: state2.isMobile ? "mobile/tablet" : "desktop",
+      attemptedMethod: "drive",
+      recordingType: state2.recording.isVideoMode ? "video" : "audio",
+      mimeType: blob.type
+    });
+    const uploadProgress = document.getElementById("upload-progress");
+    uploadProgress.style.display = "none";
+    const errorDiv = document.getElementById("recording-error");
+    errorDiv.style.display = "block";
+    errorDiv.innerHTML = `
+      <strong>Upload failed</strong>
+      <p style="margin-top: 6px;">Error: ${error.message}. You can try again or continue without uploading. The video is saved locally in your browser.</p>
+      <div class="button-group" style="margin-top: 10px;"><button class="button" onclick="retryVideoUpload()">Try Again</button><button class="button secondary" onclick="continueWithoutUpload()">Continue Without Upload</button></div>`;
+    const status = document.getElementById("recording-status");
+    status.textContent = "\u274C Upload failed";
+    status.className = "recording-status ready";
+  }
+  function cleanupRecording(state2, keepPreviewUI = false) {
+    return new Promise((resolve) => {
+      try {
+        if (state2.recording.mediaRecorder && state2.recording.mediaRecorder.state !== "inactive") {
+          state2.recording.mediaRecorder.addEventListener("stop", () => resolve(), { once: true });
+          try {
+            state2.recording.mediaRecorder.stop();
+          } catch (e) {
+            resolve();
+          }
+        } else {
+          resolve();
+        }
+      } catch (e) {
+        resolve();
+      }
+    }).finally(() => {
+      try {
+        if (state2.recording.stream) state2.recording.stream.getTracks().forEach((t) => t.stop());
+      } catch (e) {
+      }
+      state2.recording.stream = null;
+      state2.recording.active = false;
+      state2.recording.chunks = [];
+      stopRecordingTimer2(state2);
+      if (!keepPreviewUI) {
+        const preview = document.getElementById("video-preview");
+        if (preview) {
+          if (preview.pause) preview.pause();
+          preview.srcObject = null;
+          preview.style.display = "none";
+        }
+        const recorded = document.getElementById("recorded-video");
+        if (recorded) {
+          revokeRecordedURL();
+          recorded.style.display = "none";
+        }
+        state2.recording.mediaRecorder = null;
+      }
+    });
+  }
+
   // src/main.js
   var CLOUDINARY_CLOUD = "demo";
   var CLOUDINARY_PRESET = "unsigned";
@@ -778,9 +1322,8 @@ Session code: ${state.sessionCode || ""}`);
     document.getElementById("resume-code").addEventListener("input", (e) => {
       e.target.value = e.target.value.toUpperCase();
     });
-    bindRecordingSkips();
-    enhanceUploadFallback();
-    bindUploadFallback();
+    bindRecordingSkips(showSkipDialog);
+    enhanceUploadFallback(state, () => saveRecording(state, sendToSheets, completeTask));
   }
   function validateInitials(e) {
     if (e.target.id === "first-initial" || e.target.id === "last-initial") {
@@ -1320,383 +1863,16 @@ Session code: ${state.sessionCode || ""}`);
     state.recording.recordings = [];
     state.recording.currentBlob = null;
     document.getElementById("recording-content").style.display = "block";
-    updateRecordingImage();
+    updateRecordingImage(state);
     if (!window.isSecureContext) {
       document.getElementById("video-upload-fallback").style.display = "block";
-      updateRecordingImage();
+      updateRecordingImage(state);
       const status = document.getElementById("recording-status");
       status.textContent = "Recording disabled (requires https). Please use the upload option below.";
       status.className = "recording-status warning";
     }
     showScreen("recording-screen");
-    if (window.isSecureContext) startPreview();
-  }
-  function revokeRecordedURL() {
-    const recorded = document.getElementById("recorded-video");
-    if (recorded && recorded.src) {
-      try {
-        URL.revokeObjectURL(recorded.src);
-      } catch (e) {
-      }
-      recorded.removeAttribute("src");
-      if (recorded.load) recorded.load();
-    }
-  }
-  async function startPreview() {
-    const preview = document.getElementById("video-preview");
-    if (!preview) return;
-    preview.muted = true;
-    preview.playsInline = true;
-    preview.autoplay = true;
-    if (state.recording.stream) {
-      preview.srcObject = state.recording.stream;
-      preview.style.display = state.recording.isVideoMode ? "block" : "none";
-      if (state.recording.isVideoMode) preview.play().catch(() => {
-      });
-      return;
-    }
-    try {
-      const stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
-      state.recording.stream = stream;
-      state.recording.isVideoMode = true;
-      preview.srcObject = stream;
-      preview.style.display = "block";
-      preview.play().catch(() => {
-      });
-    } catch (videoErr) {
-      console.warn("Video preview failed, trying audio-only", videoErr);
-      try {
-        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-        state.recording.stream = stream;
-        state.recording.isVideoMode = false;
-        preview.style.display = "none";
-        const status = document.getElementById("recording-status");
-        status.textContent = "\u{1F3A4} Audio ready to record";
-        status.className = "recording-status ready";
-      } catch (err) {
-        console.error("Audio preview failed", err);
-        showRecordingError('<strong>Camera or microphone not available</strong><p style="margin-top: 6px;">Please upload a recording instead.</p>');
-      }
-    }
-  }
-  function updateRecordingImage() {
-    const imageNum = state.recording.currentImage + 1;
-    document.getElementById("image-number").textContent = imageNum;
-    document.getElementById("current-image").src = imageNum === 1 ? CONFIG.IMAGE_1 : CONFIG.IMAGE_2;
-    const preview = document.getElementById("video-preview");
-    const recorded = document.getElementById("recorded-video");
-    preview.style.display = "none";
-    recorded.style.display = "none";
-    revokeRecordedURL();
-    state.recording.currentBlob = null;
-    document.getElementById("record-btn").style.display = "inline-block";
-    document.getElementById("rerecord-btn").style.display = "none";
-    document.getElementById("save-recording-btn").style.display = "none";
-    const status = document.getElementById("recording-status");
-    status.textContent = "Ready to record";
-    status.className = "recording-status ready";
-    document.getElementById("recording-error").style.display = "none";
-    document.getElementById("video-upload-fallback").style.display = "none";
-    document.getElementById("upload-progress").style.display = "none";
-    const fileInput = document.getElementById("video-file-input");
-    if (fileInput) fileInput.value = "";
-    const uploadBtn = document.getElementById("upload-save-btn");
-    if (uploadBtn) {
-      uploadBtn.style.display = "none";
-      uploadBtn.textContent = "Use this upload";
-    }
-    const recordingInstructions = document.createElement("div");
-    recordingInstructions.className = "info-box important";
-    recordingInstructions.id = "recording-size-warning";
-    recordingInstructions.innerHTML = `
-  <strong>\u{1F4F9} Recording Guidelines</strong>
-  <ul style="margin: 8px 0 0 20px; text-align: left;">
-    <li><strong>Duration:</strong> Keep recordings between 30-60 seconds</li>
-    <li><strong>File size:</strong> Recordings over 45 seconds may fail to upload</li>
-    <li><strong>Language:</strong> Use ASL if you know it, otherwise spoken English</li>
-    <li><strong>Can't record?</strong> Use the "Upload a Recording" option below</li>
-  </ul>
-`;
-    const recordingContent = document.getElementById("recording-content");
-    const recordingControls = recordingContent ? recordingContent.querySelector(".recording-controls") : null;
-    if (recordingControls && recordingControls.parentNode && !document.getElementById("recording-size-warning")) {
-      recordingControls.parentNode.insertBefore(recordingInstructions, recordingControls);
-    }
-    const requiredTextRec = "This task is required for study completion.";
-    const etaRec = TASKS["ID"] && TASKS["ID"].estMinutes ? `${TASKS["ID"].estMinutes} minutes` : "a few minutes";
-    const reqsRec = TASKS["ID"] && TASKS["ID"].requirements || "\u2014";
-    const instructionBox = document.getElementById("task-instructions");
-    if (instructionBox) {
-      document.getElementById("task-title").textContent = TASKS["ID"].name;
-      instructionBox.innerHTML = `
-    <div class="info-box friendly-tip" style="margin-bottom:10px;">
-      <strong>\u26A0\uFE0F Ready to Start ${TASKS["ID"].name}?</strong>
-      <ul style="margin:8px 0 0 20px; text-align:left;">
-        <li>${requiredTextRec}</li>
-        <li>Having problems? Email us instead of skipping</li>
-        <li>Estimated time: <strong>${etaRec}</strong></li>
-        <li>Requirements/tips: <em>${reqsRec}</em></li>
-      </ul>
-    </div>
-  `;
-    }
-  }
-  function showRecordingError(html, showFallback = true) {
-    const box = document.getElementById("recording-error");
-    if (!box) return;
-    box.style.display = "block";
-    box.innerHTML = html;
-    if (showFallback) {
-      const fb = document.getElementById("video-upload-fallback");
-      if (fb) fb.style.display = "block";
-    }
-  }
-  function enhanceUploadFallback() {
-    const fallbackDiv = document.getElementById("video-upload-fallback");
-    if (fallbackDiv) {
-      fallbackDiv.innerHTML = `
-  <h3>\u{1F4C1} Upload a Recording Instead</h3>
-  <div class="info-box helpful" style="margin: 15px 0;">
-    <strong>Upload Instructions:</strong>
-    <ol style="margin: 8px 0 0 20px; text-align: left;">
-      <li>Record a 30-60 second video/audio on your device</li>
-      <li>Accepted formats: MP4, MOV, WebM (video) or MP3, M4A, WAV (audio)</li>
-      <li>Maximum size: 50MB for MP4/MOV, 40MB for WebM, 25MB for audio</li>
-      <li>Select your file below</li>
-    </ol>
-  </div>
-  <input type="file" 
-         id="video-file-input" 
-         accept="video/mp4,video/quicktime,video/webm,video/*,audio/mp3,audio/mpeg,audio/m4a,audio/wav,audio/*,.mp4,.mov,.webm,.mp3,.m4a,.wav" 
-         style="margin: 15px 0; padding: 10px; border: 2px solid var(--gray-300); border-radius: 8px; width: 100%;" />
-  <div id="file-info" style="margin: 10px 0; font-weight: bold;"></div>
-  <div class="button-group">
-    <button class="button success" id="upload-save-btn" style="display:none;">Upload This File</button>
-  </div>
-  <p style="font-size: 14px; color: var(--text-secondary); margin-top: 10px;">
-    \u{1F4A1} Tips: Use Camera app for video (iPhone/Android) or Voice Memos for audio (iPhone) or Voice Recorder (Android)
-  </p>
-`;
-    }
-  }
-  function bindUploadFallback() {
-    const input = document.getElementById("video-file-input");
-    const btn = document.getElementById("upload-save-btn");
-    const info = document.getElementById("file-info");
-    if (!input || !btn || !info) return;
-    input.addEventListener("change", () => {
-      const f = input.files && input.files[0];
-      if (!f) return;
-      if (!f.type.startsWith("video/") && !f.type.startsWith("audio/")) {
-        alert("Please select a video or audio file");
-        input.value = "";
-        info.textContent = "";
-        btn.style.display = "none";
-        return;
-      }
-      let format = "audio";
-      if (f.type.includes("mp4") || f.name.toLowerCase().endsWith(".mp4")) format = "mp4";
-      else if (f.type.includes("quicktime") || f.name.toLowerCase().endsWith(".mov")) format = "mov";
-      else if (f.type.includes("webm") || f.name.toLowerCase().endsWith(".webm")) format = "webm";
-      else if (f.type.startsWith("video/")) format = "other-video";
-      const sizeLimits = { mp4: 50, mov: 50, webm: 40, "other-video": 40, audio: 25 };
-      const maxMB = sizeLimits[format];
-      const sizeMB = f.size / (1024 * 1024);
-      if (sizeMB > maxMB) {
-        alert(`File too large: ${sizeMB.toFixed(1)}MB. Maximum for ${format.toUpperCase()} is ${maxMB}MB.`);
-        input.value = "";
-        info.textContent = "";
-        btn.style.display = "none";
-        return;
-      }
-      state.recording.currentBlob = f;
-      info.textContent = `${f.name} (${sizeMB.toFixed(1)}MB)`;
-      btn.style.display = "inline-block";
-    });
-    btn.addEventListener("click", saveRecording);
-  }
-  function bindRecordingSkips() {
-    const btn1 = document.getElementById("skip-recording-btn");
-    if (btn1) btn1.addEventListener("click", () => showSkipDialog("ID"));
-  }
-  async function toggleRecording() {
-    const btn = document.getElementById("record-btn");
-    const status = document.getElementById("recording-status");
-    const preview = document.getElementById("video-preview");
-    if (!state.recording.mediaRecorder) {
-      if (!state.recording.stream) await startPreview();
-      if (!state.recording.stream) return;
-      let mimeType;
-      if (state.recording.isVideoMode) {
-        mimeType = MediaRecorder.isTypeSupported("video/webm;codecs=vp9") ? "video/webm;codecs=vp9" : MediaRecorder.isTypeSupported("video/webm;codecs=vp8") ? "video/webm;codecs=vp8" : "video/webm";
-      } else {
-        mimeType = MediaRecorder.isTypeSupported("audio/webm;codecs=opus") ? "audio/webm;codecs=opus" : "audio/webm";
-      }
-      state.recording.chunks = [];
-      state.recording.mediaRecorder = new MediaRecorder(state.recording.stream, { mimeType });
-      state.recording.mediaRecorder.ondataavailable = (e) => {
-        if (e.data && e.data.size > 0) state.recording.chunks.push(e.data);
-      };
-      state.recording.mediaRecorder.onstop = () => {
-        const blob = new Blob(state.recording.chunks, { type: mimeType });
-        state.recording.currentBlob = blob;
-        revokeRecordedURL();
-        const recordedEl = document.getElementById("recorded-video");
-        if (state.recording.isVideoMode) {
-          recordedEl.src = URL.createObjectURL(blob);
-          recordedEl.style.display = "block";
-          preview.style.display = "none";
-        } else {
-          const audioPlayer = document.createElement("audio");
-          audioPlayer.id = "recorded-audio";
-          audioPlayer.controls = true;
-          audioPlayer.src = URL.createObjectURL(blob);
-          const container = recordedEl.parentElement;
-          const existing = document.getElementById("recorded-audio");
-          if (existing) existing.remove();
-          container.insertBefore(audioPlayer, recordedEl);
-          recordedEl.style.display = "none";
-        }
-        document.getElementById("record-btn").style.display = "none";
-        document.getElementById("rerecord-btn").style.display = "inline-block";
-        document.getElementById("save-recording-btn").style.display = "inline-block";
-        status.textContent = "\u2705 Recording complete! Ready to save.";
-        status.className = "recording-status recorded";
-        state.recording.mediaRecorder = null;
-      };
-    }
-    if (state.recording.mediaRecorder && state.recording.mediaRecorder.state === "recording") {
-      state.recording.mediaRecorder.stop();
-      btn.textContent = "Start Recording";
-      btn.className = "button danger";
-      stopRecordingTimer();
-    } else if (state.recording.mediaRecorder) {
-      state.recording.mediaRecorder.start();
-      startRecordingTimer();
-      btn.textContent = "Stop Recording";
-      btn.className = "button danger";
-      status.textContent = state.recording.isVideoMode ? "\u{1F534} Recording video..." : "\u{1F3A4} Recording audio...";
-      status.className = "recording-status recording";
-    }
-  }
-  async function reRecord() {
-    await cleanupRecording(true);
-    updateRecordingImage();
-    if (window.isSecureContext) startPreview();
-  }
-  async function saveRecording() {
-    if (!state.recording.currentBlob) {
-      alert("Please record or upload a recording first.");
-      return;
-    }
-    const saveBtn = document.getElementById("save-recording-btn");
-    const originalText = saveBtn.textContent;
-    saveBtn.disabled = true;
-    saveBtn.textContent = "Processing...";
-    const status = document.getElementById("recording-status");
-    status.textContent = "\u2699\uFE0F Processing recording...";
-    status.className = "recording-status recording";
-    const uploadProgress = document.getElementById("upload-progress");
-    uploadProgress.style.display = "block";
-    const recType = state.recording.isVideoMode ? "video" : state.recording.currentBlob && state.recording.currentBlob.type && state.recording.currentBlob.type.startsWith("audio") ? "audio" : "video";
-    sendToSheets({
-      action: "image_recorded",
-      sessionCode: state.sessionCode,
-      imageNumber: state.recording.currentImage + 1,
-      timestamp: (/* @__PURE__ */ new Date()).toISOString(),
-      recordingType: recType
-    });
-    sendToSheets({
-      action: "video_recorded",
-      sessionCode: state.sessionCode,
-      imageNumber: state.recording.currentImage + 1,
-      timestamp: (/* @__PURE__ */ new Date()).toISOString(),
-      recordingType: recType
-    });
-    try {
-      const uploadResult = await uploadVideoToDrive(
-        state.recording.currentBlob,
-        state.sessionCode,
-        state.recording.currentImage + 1,
-        sendToSheets
-      );
-      if (uploadResult.success) {
-        state.recording.recordings.push({
-          image: state.recording.currentImage + 1,
-          blob: state.recording.currentBlob,
-          timestamp: (/* @__PURE__ */ new Date()).toISOString(),
-          driveFileId: uploadResult.fileId,
-          driveFileUrl: uploadResult.fileUrl,
-          filename: uploadResult.filename,
-          uploadMethod: uploadResult.uploadMethod,
-          recordingType: state.recording.isVideoMode ? "video" : "audio",
-          mimeType: state.recording.currentBlob.type
-        });
-        const logData = {
-          action: "image_recorded_and_uploaded",
-          sessionCode: state.sessionCode,
-          imageNumber: state.recording.currentImage + 1,
-          driveFileId: uploadResult.fileId,
-          filename: uploadResult.filename,
-          timestamp: (/* @__PURE__ */ new Date()).toISOString(),
-          deviceType: state.isMobile ? "mobile/tablet" : "desktop",
-          // Enhanced fields
-          uploadMethod: uploadResult.uploadMethod,
-          fileSize: Math.round(state.recording.currentBlob.size / 1024),
-          uploadStatus: "success",
-          recordingType: state.recording.isVideoMode ? "video" : "audio",
-          mimeType: state.recording.currentBlob.type
-        };
-        sendToSheets(logData);
-        sendToSheets({
-          action: "log_video_upload",
-          sessionCode: state.sessionCode,
-          imageNumber: state.recording.currentImage + 1,
-          filename: uploadResult.filename,
-          fileId: uploadResult.fileId,
-          fileUrl: uploadResult.fileUrl,
-          fileSize: Math.round(state.recording.currentBlob.size / 1024),
-          uploadTime: (/* @__PURE__ */ new Date()).toISOString(),
-          uploadMethod: uploadResult.uploadMethod,
-          uploadStatus: "success",
-          recordingType: state.recording.isVideoMode ? "video" : "audio",
-          mimeType: state.recording.currentBlob.type
-        });
-        status.textContent = `\u2705 Upload complete via ${uploadResult.uploadMethod}!`;
-        status.className = "recording-status recorded";
-        uploadProgress.style.display = "none";
-        setTimeout(() => {
-          if (state.recording.currentImage === 0) {
-            state.recording.currentImage = 1;
-            updateRecordingImage();
-            if (window.isSecureContext) startPreview();
-          } else {
-            completeTask("ID");
-          }
-        }, 1e3);
-      } else {
-        throw new Error(uploadResult.error || "Upload failed");
-      }
-    } catch (error) {
-      console.error("Upload error:", error);
-      sendToSheets({
-        action: "log_video_upload_error",
-        sessionCode: state.sessionCode,
-        imageNumber: state.recording.currentImage + 1,
-        error: error.message,
-        timestamp: (/* @__PURE__ */ new Date()).toISOString(),
-        deviceType: state.isMobile ? "mobile/tablet" : "desktop",
-        attemptedMethod: "drive",
-        recordingType: state.recording.isVideoMode ? "video" : "audio",
-        mimeType: state.recording.currentBlob.type
-      });
-      status.textContent = "\u26A0\uFE0F Upload failed. Retrying...";
-      status.className = "recording-status recording";
-      enqueueFailedUpload(state.recording.currentBlob, state.sessionCode, state.recording.currentImage + 1);
-    } finally {
-      saveBtn.disabled = false;
-      saveBtn.textContent = originalText;
-    }
+    if (window.isSecureContext) startPreview(state);
   }
   function continueWithoutUpload() {
     if (confirm("Continue without uploading the video? The recording will only be saved locally in your browser.")) {
@@ -1723,188 +1899,12 @@ Session code: ${state.sessionCode || ""}`);
       });
       if (state.recording.currentImage === 0) {
         state.recording.currentImage = 1;
-        updateRecordingImage();
-        if (window.isSecureContext) startPreview();
+        updateRecordingImage(state);
+        if (window.isSecureContext) startPreview(state);
       } else {
         completeTask("ID");
       }
       document.getElementById("recording-error").style.display = "none";
-    }
-  }
-  function enqueueFailedUpload(blob, sessionCode, imageNumber) {
-    state.uploadQueue.push({ blob, sessionCode, imageNumber, attempts: 0 });
-    processUploadQueue();
-  }
-  async function processUploadQueue() {
-    if (state.processingUpload || state.uploadQueue.length === 0) return;
-    state.processingUpload = true;
-    const item = state.uploadQueue[0];
-    try {
-      const uploadResult = await uploadVideoToDrive(item.blob, item.sessionCode, item.imageNumber, sendToSheets);
-      if (uploadResult.success) {
-        handleUploadSuccess(uploadResult, item.imageNumber, item.blob);
-        state.uploadQueue.shift();
-      } else {
-        throw new Error(uploadResult.error || "Upload failed");
-      }
-    } catch (err) {
-      item.attempts++;
-      if (item.attempts < 3) {
-        setTimeout(() => {
-          state.processingUpload = false;
-          processUploadQueue();
-        }, 5e3 * item.attempts);
-        return;
-      }
-      state.uploadQueue.shift();
-      showUploadError(err, item.imageNumber, item.blob);
-    }
-    state.processingUpload = false;
-    if (state.uploadQueue.length > 0) processUploadQueue();
-  }
-  function handleUploadSuccess(uploadResult, imageNumber, blob) {
-    state.recording.recordings.push({
-      image: imageNumber,
-      blob,
-      timestamp: (/* @__PURE__ */ new Date()).toISOString(),
-      driveFileId: uploadResult.fileId,
-      driveFileUrl: uploadResult.fileUrl,
-      filename: uploadResult.filename,
-      uploadMethod: uploadResult.uploadMethod,
-      recordingType: state.recording.isVideoMode ? "video" : "audio",
-      mimeType: blob.type
-    });
-    const logData = {
-      action: "image_recorded_and_uploaded",
-      sessionCode: state.sessionCode,
-      imageNumber,
-      driveFileId: uploadResult.fileId,
-      filename: uploadResult.filename,
-      timestamp: (/* @__PURE__ */ new Date()).toISOString(),
-      deviceType: state.isMobile ? "mobile/tablet" : "desktop",
-      uploadMethod: uploadResult.uploadMethod,
-      fileSize: Math.round(blob.size / 1024),
-      uploadStatus: "success",
-      recordingType: state.recording.isVideoMode ? "video" : "audio",
-      mimeType: blob.type
-    };
-    sendToSheets(logData);
-    sendToSheets({
-      action: "log_video_upload",
-      sessionCode: state.sessionCode,
-      imageNumber,
-      filename: uploadResult.filename,
-      fileId: uploadResult.fileId,
-      fileUrl: uploadResult.fileUrl,
-      fileSize: Math.round(blob.size / 1024),
-      uploadTime: (/* @__PURE__ */ new Date()).toISOString(),
-      uploadMethod: uploadResult.uploadMethod,
-      uploadStatus: "success",
-      recordingType: state.recording.isVideoMode ? "video" : "audio",
-      mimeType: blob.type
-    });
-    const status = document.getElementById("recording-status");
-    status.textContent = `\u2705 Upload complete via ${uploadResult.uploadMethod}!`;
-    status.className = "recording-status recorded";
-    document.getElementById("upload-progress").style.display = "none";
-    setTimeout(() => {
-      if (imageNumber === 1 && state.recording.currentImage === 0) {
-        state.recording.currentImage = 1;
-        updateRecordingImage();
-        if (window.isSecureContext) startPreview();
-      } else {
-        completeTask("ID");
-      }
-    }, 1e3);
-  }
-  function showUploadError(error, imageNumber, blob) {
-    sendToSheets({
-      action: "log_video_upload_error",
-      sessionCode: state.sessionCode,
-      imageNumber,
-      error: error.message,
-      timestamp: (/* @__PURE__ */ new Date()).toISOString(),
-      deviceType: state.isMobile ? "mobile/tablet" : "desktop",
-      attemptedMethod: "drive",
-      recordingType: state.recording.isVideoMode ? "video" : "audio",
-      mimeType: blob.type
-    });
-    const uploadProgress = document.getElementById("upload-progress");
-    uploadProgress.style.display = "none";
-    const errorDiv = document.getElementById("recording-error");
-    errorDiv.style.display = "block";
-    errorDiv.innerHTML = `
-      <strong>Upload failed</strong>
-      <p style="margin-top: 6px;">Error: ${error.message}. You can try again or continue without uploading. The video is saved locally in your browser.</p>
-      <div class="button-group" style="margin-top: 10px;"><button class="button" onclick="retryVideoUpload()">Try Again</button><button class="button secondary" onclick="continueWithoutUpload()">Continue Without Upload</button></div>`;
-    const status = document.getElementById("recording-status");
-    status.textContent = "\u274C Upload failed";
-    status.className = "recording-status ready";
-  }
-  async function retryVideoUpload() {
-    document.getElementById("recording-error").style.display = "none";
-    await saveRecording();
-  }
-  function cleanupRecording(keepPreviewUI = false) {
-    return new Promise((resolve) => {
-      try {
-        if (state.recording.mediaRecorder && state.recording.mediaRecorder.state !== "inactive") {
-          state.recording.mediaRecorder.addEventListener("stop", () => resolve(), { once: true });
-          try {
-            state.recording.mediaRecorder.stop();
-          } catch (e) {
-            resolve();
-          }
-        } else {
-          resolve();
-        }
-      } catch (e) {
-        resolve();
-      }
-    }).finally(() => {
-      try {
-        if (state.recording.stream) state.recording.stream.getTracks().forEach((t) => t.stop());
-      } catch (e) {
-      }
-      state.recording.stream = null;
-      state.recording.active = false;
-      state.recording.chunks = [];
-      stopRecordingTimer();
-      if (!keepPreviewUI) {
-        const preview = document.getElementById("video-preview");
-        if (preview) {
-          if (preview.pause) preview.pause();
-          preview.srcObject = null;
-          preview.style.display = "none";
-        }
-        const recorded = document.getElementById("recorded-video");
-        if (recorded) {
-          revokeRecordedURL();
-          recorded.style.display = "none";
-        }
-        state.recording.mediaRecorder = null;
-      }
-    });
-  }
-  var recordingTimer;
-  function startRecordingTimer() {
-    const timer = document.getElementById("recording-timer");
-    timer.style.display = "block";
-    let seconds = 0;
-    state.recording.recordingStart = Date.now();
-    recordingTimer = setInterval(() => {
-      seconds++;
-      const mins = Math.floor(seconds / 60);
-      const secs = seconds % 60;
-      timer.textContent = `${mins.toString().padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
-    }, 1e3);
-  }
-  function stopRecordingTimer() {
-    clearInterval(recordingTimer);
-    const t = document.getElementById("recording-timer");
-    if (t) t.style.display = "none";
-    if (state.recording.recordingStart) {
-      state.recording.recordingDuration = Date.now() - state.recording.recordingStart;
     }
   }
   function completeTask(taskCode) {
@@ -2191,7 +2191,7 @@ Thank you!`);
   async function skipTaskProceed(taskCode) {
     if (taskCode === "ID") {
       try {
-        await cleanupRecording();
+        await cleanupRecording(state);
       } catch (e) {
       }
     }
@@ -2490,14 +2490,14 @@ Thank you!`);
     markComplete,
     openEmbedInNewTab,
     reloadEmbed,
-    retryVideoUpload,
+    retryVideoUpload: () => retryVideoUpload(state, sendToSheets, completeTask),
     showScreen,
     showSkipDialog,
     skipCurrentTask,
     skipTask,
     skipTaskProceed,
-    toggleRecording,
-    reRecord,
-    saveRecording
+    toggleRecording: () => toggleRecording(state),
+    reRecord: () => reRecord(state),
+    saveRecording: () => saveRecording(state, sendToSheets, completeTask)
   });
 })();

--- a/src/main.js
+++ b/src/main.js
@@ -9,8 +9,18 @@ import {
   ensureDemographicsLast,
   isMobileDevice
 } from './tasks.js';
-import { uploadVideoToDrive } from './videoUpload.js';
 import { debugVideoUpload, testCloudinaryUpload } from './debug.js';
+import {
+  startPreview,
+  updateRecordingImage,
+  enhanceUploadFallback,
+  bindRecordingSkips,
+  toggleRecording,
+  reRecord,
+  saveRecording,
+  retryVideoUpload,
+  cleanupRecording
+} from './recorder.js';
 
 // ----- Configuration -----
 /* === MS-RECORDER-CONFIG START === */
@@ -404,9 +414,8 @@ if (document.readyState === 'loading') {
       document.getElementById('consent-code').addEventListener('input', validateInitials);
       document.getElementById('consent-confirm').addEventListener('change', validateInitials);
       document.getElementById('resume-code').addEventListener('input', e => { e.target.value = e.target.value.toUpperCase(); });
-      bindRecordingSkips();
-      enhanceUploadFallback();
-      bindUploadFallback();
+        bindRecordingSkips(showSkipDialog);
+        enhanceUploadFallback(state, () => saveRecording(state, sendToSheets, completeTask));
     }
 
     function validateInitials(e) {
@@ -983,454 +992,23 @@ function openExternalTask(taskCode) {
 }
 
     // ----- Recording task -----
-    function showRecordingTask() {
-      state.recording.currentImage = 0;
-      state.recording.recordings = [];
-      state.recording.currentBlob = null;
-      document.getElementById('recording-content').style.display = 'block';
-      updateRecordingImage();
-      // NEW: if page not secure, skip recorder UI and show upload UI
-      if (!window.isSecureContext) {
-        document.getElementById('video-upload-fallback').style.display = 'block';
-        // Ensure the current image is shown even without recording
-        updateRecordingImage();
-        const status = document.getElementById('recording-status');
-        status.textContent = 'Recording disabled (requires https). Please use the upload option below.';
-        status.className = 'recording-status warning';
-      }
-
-      showScreen('recording-screen');
-      if (window.isSecureContext) startPreview();
-    }
-
-    function revokeRecordedURL() {
-      const recorded = document.getElementById('recorded-video');
-      if (recorded && recorded.src) {
-        try { URL.revokeObjectURL(recorded.src); } catch(e) {}
-        recorded.removeAttribute('src');
-        if (recorded.load) recorded.load();
-      }
-    }
-
-    async function startPreview() {
-      const preview = document.getElementById('video-preview');
-      if (!preview) return;
-      preview.muted = true;
-      preview.playsInline = true;
-      preview.autoplay = true;
-      if (state.recording.stream) {
-        preview.srcObject = state.recording.stream;
-        preview.style.display = state.recording.isVideoMode ? 'block' : 'none';
-        if (state.recording.isVideoMode) preview.play().catch(() => {});
-        return;
-      }
-      try {
-        const stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
-        state.recording.stream = stream;
-        state.recording.isVideoMode = true;
-        preview.srcObject = stream;
-        preview.style.display = 'block';
-        preview.play().catch(() => {});
-      } catch (videoErr) {
-        console.warn('Video preview failed, trying audio-only', videoErr);
-        try {
-          const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-          state.recording.stream = stream;
-          state.recording.isVideoMode = false;
-          preview.style.display = 'none';
+      function showRecordingTask() {
+        state.recording.currentImage = 0;
+        state.recording.recordings = [];
+        state.recording.currentBlob = null;
+        document.getElementById('recording-content').style.display = 'block';
+        updateRecordingImage(state);
+        if (!window.isSecureContext) {
+          document.getElementById('video-upload-fallback').style.display = 'block';
+          updateRecordingImage(state);
           const status = document.getElementById('recording-status');
-          status.textContent = '🎤 Audio ready to record';
-          status.className = 'recording-status ready';
-        } catch (err) {
-          console.error('Audio preview failed', err);
-          showRecordingError('<strong>Camera or microphone not available</strong><p style="margin-top: 6px;">Please upload a recording instead.</p>');
-        }
-      }
-    }
-
-    function updateRecordingImage() {
-      const imageNum = state.recording.currentImage + 1;
-      document.getElementById('image-number').textContent = imageNum;
-      document.getElementById('current-image').src = imageNum === 1 ? CONFIG.IMAGE_1 : CONFIG.IMAGE_2;
-      
-      const preview = document.getElementById('video-preview');
-      const recorded = document.getElementById('recorded-video');
-      preview.style.display = 'none';
-      recorded.style.display = 'none';
-      
-      // Clean up previous recording blob URL
-      revokeRecordedURL();
-      state.recording.currentBlob = null;
-      
-      // Reset UI elements
-      document.getElementById('record-btn').style.display = 'inline-block';
-      document.getElementById('rerecord-btn').style.display = 'none';
-      document.getElementById('save-recording-btn').style.display = 'none';
-      
-      const status = document.getElementById('recording-status');
-      status.textContent = 'Ready to record';
-      status.className = 'recording-status ready';
-      
-      // Clear any previous errors
-      document.getElementById('recording-error').style.display = 'none';
-      document.getElementById('video-upload-fallback').style.display = 'none';
-      document.getElementById('upload-progress').style.display = 'none';
-      
-      // Clear file input
-      const fileInput = document.getElementById('video-file-input');
-      if (fileInput) fileInput.value = '';
-      
-      const uploadBtn = document.getElementById('upload-save-btn');
-      if (uploadBtn) {
-        uploadBtn.style.display = 'none';
-        uploadBtn.textContent = 'Use this upload';
-      }
-
-      // Add recording instructions with size warning
-      const recordingInstructions = document.createElement('div');
-      recordingInstructions.className = 'info-box important';
-      recordingInstructions.id = 'recording-size-warning';
-      recordingInstructions.innerHTML = `
-  <strong>📹 Recording Guidelines</strong>
-  <ul style="margin: 8px 0 0 20px; text-align: left;">
-    <li><strong>Duration:</strong> Keep recordings between 30-60 seconds</li>
-    <li><strong>File size:</strong> Recordings over 45 seconds may fail to upload</li>
-    <li><strong>Language:</strong> Use ASL if you know it, otherwise spoken English</li>
-    <li><strong>Can't record?</strong> Use the "Upload a Recording" option below</li>
-  </ul>
-`;
-
-      // Insert before recording controls
-      const recordingContent = document.getElementById('recording-content');
-      const recordingControls = recordingContent ? recordingContent.querySelector('.recording-controls') : null;
-      if (recordingControls && recordingControls.parentNode && !document.getElementById('recording-size-warning')) {
-      recordingControls.parentNode.insertBefore(recordingInstructions, recordingControls);
-      }
-
-      const requiredTextRec = 'This task is required for study completion.';
-const etaRec = (TASKS['ID'] && TASKS['ID'].estMinutes) ? `${TASKS['ID'].estMinutes} minutes` : 'a few minutes';
-const reqsRec = (TASKS['ID'] && TASKS['ID'].requirements) || '—';
-
-const instructionBox = document.getElementById('task-instructions');
-if (instructionBox) {
-  document.getElementById('task-title').textContent = TASKS['ID'].name;
-  instructionBox.innerHTML = `
-    <div class="info-box friendly-tip" style="margin-bottom:10px;">
-      <strong>⚠️ Ready to Start ${TASKS['ID'].name}?</strong>
-      <ul style="margin:8px 0 0 20px; text-align:left;">
-        <li>${requiredTextRec}</li>
-        <li>Having problems? Email us instead of skipping</li>
-        <li>Estimated time: <strong>${etaRec}</strong></li>
-        <li>Requirements/tips: <em>${reqsRec}</em></li>
-      </ul>
-    </div>
-  `;
-}
-
-      }
-
-      // Removed complex permission checks in favor of direct getUserMedia attempts for broader browser support
-
-    function showRecordingError(html, showFallback = true) {
-      const box = document.getElementById('recording-error');
-      if (!box) return;
-      box.style.display = 'block';
-      box.innerHTML = html;
-      if (showFallback) {
-        const fb = document.getElementById('video-upload-fallback');
-        if (fb) fb.style.display = 'block';
-      }
-    }
-
-    // Enhanced file upload handling for the fallback option
-    function enhanceUploadFallback() {
-      const fallbackDiv = document.getElementById('video-upload-fallback');
-      if (fallbackDiv) {
-        fallbackDiv.innerHTML = `
-  <h3>📁 Upload a Recording Instead</h3>
-  <div class="info-box helpful" style="margin: 15px 0;">
-    <strong>Upload Instructions:</strong>
-    <ol style="margin: 8px 0 0 20px; text-align: left;">
-      <li>Record a 30-60 second video/audio on your device</li>
-      <li>Accepted formats: MP4, MOV, WebM (video) or MP3, M4A, WAV (audio)</li>
-      <li>Maximum size: 50MB for MP4/MOV, 40MB for WebM, 25MB for audio</li>
-      <li>Select your file below</li>
-    </ol>
-  </div>
-  <input type="file" 
-         id="video-file-input" 
-         accept="video/mp4,video/quicktime,video/webm,video/*,audio/mp3,audio/mpeg,audio/m4a,audio/wav,audio/*,.mp4,.mov,.webm,.mp3,.m4a,.wav" 
-         style="margin: 15px 0; padding: 10px; border: 2px solid var(--gray-300); border-radius: 8px; width: 100%;" />
-  <div id="file-info" style="margin: 10px 0; font-weight: bold;"></div>
-  <div class="button-group">
-    <button class="button success" id="upload-save-btn" style="display:none;">Upload This File</button>
-  </div>
-  <p style="font-size: 14px; color: var(--text-secondary); margin-top: 10px;">
-    💡 Tips: Use Camera app for video (iPhone/Android) or Voice Memos for audio (iPhone) or Voice Recorder (Android)
-  </p>
-`;
-      }
-    }
-
-    function bindUploadFallback() {
-      const input = document.getElementById('video-file-input');
-      const btn = document.getElementById('upload-save-btn');
-      const info = document.getElementById('file-info');
-      if (!input || !btn || !info) return;
-
-      input.addEventListener('change', () => {
-        const f = input.files && input.files[0];
-        if (!f) return;
-
-        if (!f.type.startsWith('video/') && !f.type.startsWith('audio/')) {
-          alert('Please select a video or audio file');
-          input.value = '';
-          info.textContent = '';
-          btn.style.display = 'none';
-          return;
+          status.textContent = 'Recording disabled (requires https). Please use the upload option below.';
+          status.className = 'recording-status warning';
         }
 
-        // Determine format for size limit
-        let format = 'audio';
-        if (f.type.includes('mp4') || f.name.toLowerCase().endsWith('.mp4')) format = 'mp4';
-        else if (f.type.includes('quicktime') || f.name.toLowerCase().endsWith('.mov')) format = 'mov';
-        else if (f.type.includes('webm') || f.name.toLowerCase().endsWith('.webm')) format = 'webm';
-        else if (f.type.startsWith('video/')) format = 'other-video';
-
-        const sizeLimits = { mp4: 50, mov: 50, webm: 40, 'other-video': 40, audio: 25 };
-        const maxMB = sizeLimits[format];
-        const sizeMB = f.size / (1024 * 1024);
-        if (sizeMB > maxMB) {
-          alert(`File too large: ${sizeMB.toFixed(1)}MB. Maximum for ${format.toUpperCase()} is ${maxMB}MB.`);
-          input.value = '';
-          info.textContent = '';
-          btn.style.display = 'none';
-          return;
-        }
-
-        state.recording.currentBlob = f;
-        info.textContent = `${f.name} (${sizeMB.toFixed(1)}MB)`;
-        btn.style.display = 'inline-block';
-      });
-
-      btn.addEventListener('click', saveRecording);
-    }
-
-function bindRecordingSkips() {
-      const btn1 = document.getElementById('skip-recording-btn');
-      if (btn1) btn1.addEventListener('click', () => showSkipDialog('ID'));
-    }
-
-
-    async function toggleRecording() {
-      const btn = document.getElementById('record-btn');
-      const status = document.getElementById('recording-status');
-      const preview = document.getElementById('video-preview');
-      if (!state.recording.mediaRecorder) {
-        if (!state.recording.stream) await startPreview();
-        if (!state.recording.stream) return;
-        let mimeType;
-        if (state.recording.isVideoMode) {
-          mimeType = MediaRecorder.isTypeSupported('video/webm;codecs=vp9') ? 'video/webm;codecs=vp9' :
-            MediaRecorder.isTypeSupported('video/webm;codecs=vp8') ? 'video/webm;codecs=vp8' : 'video/webm';
-        } else {
-          mimeType = MediaRecorder.isTypeSupported('audio/webm;codecs=opus') ? 'audio/webm;codecs=opus' : 'audio/webm';
-        }
-        state.recording.chunks = [];
-        state.recording.mediaRecorder = new MediaRecorder(state.recording.stream, { mimeType });
-        state.recording.mediaRecorder.ondataavailable = e => {
-          if (e.data && e.data.size > 0) state.recording.chunks.push(e.data);
-        };
-        state.recording.mediaRecorder.onstop = () => {
-          const blob = new Blob(state.recording.chunks, { type: mimeType });
-          state.recording.currentBlob = blob;
-          revokeRecordedURL();
-          const recordedEl = document.getElementById('recorded-video');
-          if (state.recording.isVideoMode) {
-            recordedEl.src = URL.createObjectURL(blob);
-            recordedEl.style.display = 'block';
-            preview.style.display = 'none';
-          } else {
-            const audioPlayer = document.createElement('audio');
-            audioPlayer.id = 'recorded-audio';
-            audioPlayer.controls = true;
-            audioPlayer.src = URL.createObjectURL(blob);
-            const container = recordedEl.parentElement;
-            const existing = document.getElementById('recorded-audio');
-            if (existing) existing.remove();
-            container.insertBefore(audioPlayer, recordedEl);
-            recordedEl.style.display = 'none';
-          }
-          document.getElementById('record-btn').style.display = 'none';
-          document.getElementById('rerecord-btn').style.display = 'inline-block';
-          document.getElementById('save-recording-btn').style.display = 'inline-block';
-          status.textContent = '✅ Recording complete! Ready to save.';
-          status.className = 'recording-status recorded';
-          state.recording.mediaRecorder = null;
-        };
+        showScreen('recording-screen');
+        if (window.isSecureContext) startPreview(state);
       }
-      if (state.recording.mediaRecorder && state.recording.mediaRecorder.state === 'recording') {
-        state.recording.mediaRecorder.stop();
-        btn.textContent = 'Start Recording';
-        btn.className = 'button danger';
-        stopRecordingTimer();
-      } else if (state.recording.mediaRecorder) {
-        state.recording.mediaRecorder.start();
-        startRecordingTimer();
-        btn.textContent = 'Stop Recording';
-        btn.className = 'button danger';
-        status.textContent = state.recording.isVideoMode ? '🔴 Recording video...' : '🎤 Recording audio...';
-        status.className = 'recording-status recording';
-      }
-    }
-
-    async function reRecord() {
-      await cleanupRecording(true);
-      updateRecordingImage();
-      if (window.isSecureContext) startPreview();
-    }
-
-    // Updated saveRecording function with Google Drive upload
-// Updated saveRecording function with enhanced logging
-async function saveRecording() {
-  if (!state.recording.currentBlob) {
-    alert('Please record or upload a recording first.');
-    return;
-  }
-
-  const saveBtn = document.getElementById('save-recording-btn');
-  const originalText = saveBtn.textContent;
-  saveBtn.disabled = true;
-  saveBtn.textContent = 'Processing...';
-
-  const status = document.getElementById('recording-status');
-  status.textContent = '⚙️ Processing recording...';
-  status.className = 'recording-status recording';
-
-  const uploadProgress = document.getElementById('upload-progress');
-  uploadProgress.style.display = 'block';
-
-  const recType = state.recording.isVideoMode ? 'video'
-    : (state.recording.currentBlob && state.recording.currentBlob.type && state.recording.currentBlob.type.startsWith('audio') ? 'audio' : 'video');
-
-  sendToSheets({
-    action: 'image_recorded',
-    sessionCode: state.sessionCode,
-    imageNumber: state.recording.currentImage + 1,
-    timestamp: new Date().toISOString(),
-    recordingType: recType
-  });
-
-  sendToSheets({
-    action: 'video_recorded',
-    sessionCode: state.sessionCode,
-    imageNumber: state.recording.currentImage + 1,
-    timestamp: new Date().toISOString(),
-    recordingType: recType
-  });
-
-  try {
-    // Upload with enhanced tracking
-    const uploadResult = await uploadVideoToDrive(
-      state.recording.currentBlob,
-      state.sessionCode,
-      state.recording.currentImage + 1,
-      sendToSheets
-    );
-
-    if (uploadResult.success) {
-      // Store the upload info with method tracking
-      state.recording.recordings.push({
-        image: state.recording.currentImage + 1,
-        blob: state.recording.currentBlob,
-        timestamp: new Date().toISOString(),
-        driveFileId: uploadResult.fileId,
-        driveFileUrl: uploadResult.fileUrl,
-        filename: uploadResult.filename,
-        uploadMethod: uploadResult.uploadMethod,
-        recordingType: state.recording.isVideoMode ? 'video' : 'audio',
-        mimeType: state.recording.currentBlob.type
-      });
-
-      // Enhanced logging to Google Sheets
-      const logData = {
-        action: 'image_recorded_and_uploaded',
-        sessionCode: state.sessionCode,
-        imageNumber: state.recording.currentImage + 1,
-        driveFileId: uploadResult.fileId,
-        filename: uploadResult.filename,
-        timestamp: new Date().toISOString(),
-        deviceType: state.isMobile ? 'mobile/tablet' : 'desktop',
-        // Enhanced fields
-        uploadMethod: uploadResult.uploadMethod,
-        fileSize: Math.round(state.recording.currentBlob.size / 1024),
-        uploadStatus: 'success',
-        recordingType: state.recording.isVideoMode ? 'video' : 'audio',
-        mimeType: state.recording.currentBlob.type
-      };
-
-      // Send to both the task logging and video upload logging
-      sendToSheets(logData);
-      
-      // Also log specifically to video uploads table
-        sendToSheets({
-          action: 'log_video_upload',
-          sessionCode: state.sessionCode,
-          imageNumber: state.recording.currentImage + 1,
-          filename: uploadResult.filename,
-          fileId: uploadResult.fileId,
-          fileUrl: uploadResult.fileUrl,
-          fileSize: Math.round(state.recording.currentBlob.size / 1024),
-          uploadTime: new Date().toISOString(),
-          uploadMethod: uploadResult.uploadMethod,
-          uploadStatus: 'success',
-          recordingType: state.recording.isVideoMode ? 'video' : 'audio',
-          mimeType: state.recording.currentBlob.type
-        });
-
-      status.textContent = `✅ Upload complete via ${uploadResult.uploadMethod}!`;
-      status.className = 'recording-status recorded';
-      uploadProgress.style.display = 'none';
-
-      setTimeout(() => {
-        if (state.recording.currentImage === 0) {
-          state.recording.currentImage = 1;
-          updateRecordingImage();
-          if (window.isSecureContext) startPreview();
-        } else {
-          completeTask('ID');
-        }
-      }, 1000);
-
-    } else {
-      throw new Error(uploadResult.error || 'Upload failed');
-    }
-
-  } catch (error) {
-    console.error('Upload error:', error);
-
-    // Enhanced error logging
-    sendToSheets({
-      action: 'log_video_upload_error',
-      sessionCode: state.sessionCode,
-      imageNumber: state.recording.currentImage + 1,
-      error: error.message,
-      timestamp: new Date().toISOString(),
-      deviceType: state.isMobile ? 'mobile/tablet' : 'desktop',
-      attemptedMethod: 'drive',
-      recordingType: state.recording.isVideoMode ? 'video' : 'audio',
-      mimeType: state.recording.currentBlob.type
-    });
-
-    status.textContent = '⚠️ Upload failed. Retrying...';
-    status.className = 'recording-status recording';
-    enqueueFailedUpload(state.recording.currentBlob, state.sessionCode, state.recording.currentImage + 1);
-  } finally {
-    saveBtn.disabled = false;
-    saveBtn.textContent = originalText;
-  }
-}
-
 // Updated continueWithoutUpload with enhanced logging
 function continueWithoutUpload() {
   if (confirm('Continue without uploading the video? The recording will only be saved locally in your browser.')) {
@@ -1458,166 +1036,19 @@ function continueWithoutUpload() {
       mimeType: state.recording.currentBlob.type
     });
 
-    if (state.recording.currentImage === 0) {
-      state.recording.currentImage = 1;
-      updateRecordingImage();
-      if (window.isSecureContext) startPreview();
-    } else {
-      completeTask('ID');
-    }
+      if (state.recording.currentImage === 0) {
+        state.recording.currentImage = 1;
+        updateRecordingImage(state);
+        if (window.isSecureContext) startPreview(state);
+      } else {
+        completeTask('ID');
+      }
     
     document.getElementById('recording-error').style.display = 'none';
   }
 }
 
-// Enhanced upload function - uses Google Drive for uploads
-    function enqueueFailedUpload(blob, sessionCode, imageNumber) {
-      state.uploadQueue.push({ blob, sessionCode, imageNumber, attempts: 0 });
-      processUploadQueue();
-    }
-
-    async function processUploadQueue() {
-      if (state.processingUpload || state.uploadQueue.length === 0) return;
-      state.processingUpload = true;
-      const item = state.uploadQueue[0];
-      try {
-        const uploadResult = await uploadVideoToDrive(item.blob, item.sessionCode, item.imageNumber, sendToSheets);
-        if (uploadResult.success) {
-          handleUploadSuccess(uploadResult, item.imageNumber, item.blob);
-          state.uploadQueue.shift();
-        } else {
-          throw new Error(uploadResult.error || 'Upload failed');
-        }
-      } catch (err) {
-        item.attempts++;
-        if (item.attempts < 3) {
-          setTimeout(() => { state.processingUpload = false; processUploadQueue(); }, 5000 * item.attempts);
-          return;
-        }
-        state.uploadQueue.shift();
-        showUploadError(err, item.imageNumber, item.blob);
-      }
-      state.processingUpload = false;
-      if (state.uploadQueue.length > 0) processUploadQueue();
-    }
-
-    function handleUploadSuccess(uploadResult, imageNumber, blob) {
-      state.recording.recordings.push({
-        image: imageNumber,
-        blob,
-        timestamp: new Date().toISOString(),
-        driveFileId: uploadResult.fileId,
-        driveFileUrl: uploadResult.fileUrl,
-        filename: uploadResult.filename,
-        uploadMethod: uploadResult.uploadMethod,
-        recordingType: state.recording.isVideoMode ? 'video' : 'audio',
-        mimeType: blob.type
-      });
-
-      const logData = {
-        action: 'image_recorded_and_uploaded',
-        sessionCode: state.sessionCode,
-        imageNumber,
-        driveFileId: uploadResult.fileId,
-        filename: uploadResult.filename,
-        timestamp: new Date().toISOString(),
-        deviceType: state.isMobile ? 'mobile/tablet' : 'desktop',
-        uploadMethod: uploadResult.uploadMethod,
-        fileSize: Math.round(blob.size / 1024),
-        uploadStatus: 'success',
-        recordingType: state.recording.isVideoMode ? 'video' : 'audio',
-        mimeType: blob.type
-      };
-      sendToSheets(logData);
-      sendToSheets({
-        action: 'log_video_upload',
-        sessionCode: state.sessionCode,
-        imageNumber,
-        filename: uploadResult.filename,
-        fileId: uploadResult.fileId,
-        fileUrl: uploadResult.fileUrl,
-        fileSize: Math.round(blob.size / 1024),
-        uploadTime: new Date().toISOString(),
-        uploadMethod: uploadResult.uploadMethod,
-        uploadStatus: 'success',
-        recordingType: state.recording.isVideoMode ? 'video' : 'audio',
-        mimeType: blob.type
-      });
-
-      const status = document.getElementById('recording-status');
-      status.textContent = `✅ Upload complete via ${uploadResult.uploadMethod}!`;
-      status.className = 'recording-status recorded';
-      document.getElementById('upload-progress').style.display = 'none';
-
-      setTimeout(() => {
-        if (imageNumber === 1 && state.recording.currentImage === 0) {
-          state.recording.currentImage = 1;
-          updateRecordingImage();
-          if (window.isSecureContext) startPreview();
-        } else {
-          completeTask('ID');
-        }
-      }, 1000);
-    }
-
-    function showUploadError(error, imageNumber, blob) {
-      sendToSheets({
-        action: 'log_video_upload_error',
-        sessionCode: state.sessionCode,
-        imageNumber,
-        error: error.message,
-        timestamp: new Date().toISOString(),
-        deviceType: state.isMobile ? 'mobile/tablet' : 'desktop',
-        attemptedMethod: 'drive',
-        recordingType: state.recording.isVideoMode ? 'video' : 'audio',
-        mimeType: blob.type
-      });
-
-      const uploadProgress = document.getElementById('upload-progress');
-      uploadProgress.style.display = 'none';
-      const errorDiv = document.getElementById('recording-error');
-      errorDiv.style.display = 'block';
-      errorDiv.innerHTML = `
-      <strong>Upload failed</strong>
-      <p style="margin-top: 6px;">Error: ${error.message}. You can try again or continue without uploading. The video is saved locally in your browser.</p>
-      <div class="button-group" style="margin-top: 10px;"><button class="button" onclick="retryVideoUpload()">Try Again</button><button class="button secondary" onclick="continueWithoutUpload()">Continue Without Upload</button></div>`;
-      const status = document.getElementById('recording-status');
-      status.textContent = '❌ Upload failed';
-      status.className = 'recording-status ready';
-    }
-
-    // Retry upload function
-    async function retryVideoUpload() {
-      document.getElementById('recording-error').style.display = 'none';
-      await saveRecording();
-    }
-
-      function cleanupRecording(keepPreviewUI = false) {
-      return new Promise(resolve => {
-        try {
-          if (state.recording.mediaRecorder && state.recording.mediaRecorder.state !== 'inactive') {
-            state.recording.mediaRecorder.addEventListener('stop', () => resolve(), { once: true });
-            try { state.recording.mediaRecorder.stop(); } catch(e) { resolve(); }
-          } else { resolve(); }
-        } catch(e) { resolve(); }
-      }).finally(() => {
-        try { if (state.recording.stream) state.recording.stream.getTracks().forEach(t => t.stop()); } catch(e){}
-        state.recording.stream = null;
-        state.recording.active = false;
-        state.recording.chunks = [];
-        stopRecordingTimer();
-
-        if (!keepPreviewUI) {
-          const preview = document.getElementById('video-preview');
-          if (preview) { if (preview.pause) preview.pause(); preview.srcObject = null; preview.style.display = 'none'; }
-          const recorded = document.getElementById('recorded-video');
-          if (recorded) { revokeRecordedURL(); recorded.style.display = 'none'; }
-          state.recording.mediaRecorder = null;
-        }
-      });
-    }
-
-    function ensureTaskPointer(taskCode) {
+function ensureTaskPointer(taskCode) {
       if (!state.sequence || !state.sequence.length) return;
       if (state.sequence[state.currentTaskIndex] !== taskCode) {
         const idx = state.sequence.indexOf(taskCode);
@@ -1627,29 +1058,10 @@ function continueWithoutUpload() {
 
     async function skipRecording() {
       if (!confirm('Unable to complete the image description task?')) return;
-      try { await cleanupRecording(); } catch(e) { console.warn('Cleanup on skip failed silently:', e); }
+        try { await cleanupRecording(state); } catch(e) { console.warn('Cleanup on skip failed silently:', e); }
       ensureTaskPointer('ID'); skipTask('ID');
     }
-
-    let recordingTimer;
-    function startRecordingTimer() {
-      const timer = document.getElementById('recording-timer'); timer.style.display = 'block';
-      let seconds = 0;
-      state.recording.recordingStart = Date.now();
-      recordingTimer = setInterval(() => {
-        seconds++; const mins = Math.floor(seconds/60); const secs = seconds % 60;
-        timer.textContent = `${mins.toString().padStart(2,'0')}:${secs.toString().padStart(2,'0')}`;
-      }, 1000);
-    }
-    function stopRecordingTimer() {
-      clearInterval(recordingTimer);
-      const t = document.getElementById('recording-timer'); if (t) t.style.display = 'none';
-      if (state.recording.recordingStart) {
-        state.recording.recordingDuration = Date.now() - state.recording.recordingStart;
-      }
-    }
-
-    // ----- Complete/Skip -----
+  // ----- Complete/Skip -----
     function completeTask(taskCode) {
       const task = TASKS[taskCode]; if (!task) { console.error('Task not found:', taskCode); return; }
       taskTimer.stop();
@@ -1944,13 +1356,12 @@ Thank you!`);
 }
 
 // Do the actual skip (handles video task cleanup)
-async function skipTaskProceed(taskCode) {
-  if (taskCode === 'ID') {
-    try { await cleanupRecording(); } catch(e) {}
+  async function skipTaskProceed(taskCode) {
+    if (taskCode === 'ID') {
+      try { await cleanupRecording(state); } catch(e) {}
+    }
+    skipTask(taskCode);
   }
-  // Call your existing skip function
-  skipTask(taskCode);
-}
 
 
     function hashCode(str) { let hash = 0; for (let i=0;i<str.length;i++){const c=str.charCodeAt(i); hash=((hash<<5)-hash)+c; hash|=0;} return hash; }
@@ -2287,19 +1698,19 @@ Object.assign(window, {
   // Task flow helpers
   completeTask,
   continueToCurrentTask,
-  continueWithoutUpload,
-  markComplete,
-  openEmbedInNewTab,
-  reloadEmbed,
-  retryVideoUpload,
-  showScreen,
-  showSkipDialog,
-  skipCurrentTask,
-  skipTask,
-  skipTaskProceed,
-  toggleRecording,
-  reRecord,
-  saveRecording,
+    continueWithoutUpload,
+    markComplete,
+    openEmbedInNewTab,
+    reloadEmbed,
+    retryVideoUpload: () => retryVideoUpload(state, sendToSheets, completeTask),
+    showScreen,
+    showSkipDialog,
+    skipCurrentTask,
+    skipTask,
+    skipTaskProceed,
+    toggleRecording: () => toggleRecording(state),
+    reRecord: () => reRecord(state),
+    saveRecording: () => saveRecording(state, sendToSheets, completeTask),
 
 
 });

--- a/src/recorder.js
+++ b/src/recorder.js
@@ -1,0 +1,598 @@
+import { CONFIG } from './config.js';
+import { TASKS } from './tasks.js';
+import { uploadVideoToDrive } from './videoUpload.js';
+
+function revokeRecordedURL() {
+  const recorded = document.getElementById('recorded-video');
+  if (recorded && recorded.src) {
+    try { URL.revokeObjectURL(recorded.src); } catch (e) {}
+    recorded.removeAttribute('src');
+    if (recorded.load) recorded.load();
+  }
+}
+
+export async function startPreview(state) {
+  const preview = document.getElementById('video-preview');
+  if (!preview) return;
+  preview.muted = true;
+  preview.playsInline = true;
+  preview.autoplay = true;
+  if (state.recording.stream) {
+    preview.srcObject = state.recording.stream;
+    preview.style.display = state.recording.isVideoMode ? 'block' : 'none';
+    if (state.recording.isVideoMode) preview.play().catch(() => {});
+    return;
+  }
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+    state.recording.stream = stream;
+    state.recording.isVideoMode = true;
+    preview.srcObject = stream;
+    preview.style.display = 'block';
+    preview.play().catch(() => {});
+  } catch (videoErr) {
+    console.warn('Video preview failed, trying audio-only', videoErr);
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      state.recording.stream = stream;
+      state.recording.isVideoMode = false;
+      preview.style.display = 'none';
+      const status = document.getElementById('recording-status');
+      status.textContent = '🎤 Audio ready to record';
+      status.className = 'recording-status ready';
+    } catch (err) {
+      console.error('Audio preview failed', err);
+      showRecordingError('<strong>Camera or microphone not available</strong><p style="margin-top: 6px;">Please upload a recording instead.</p>');
+    }
+  }
+}
+
+export function updateRecordingImage(state) {
+  const imageNum = state.recording.currentImage + 1;
+  document.getElementById('image-number').textContent = imageNum;
+  document.getElementById('current-image').src = imageNum === 1 ? CONFIG.IMAGE_1 : CONFIG.IMAGE_2;
+
+  const preview = document.getElementById('video-preview');
+  const recorded = document.getElementById('recorded-video');
+  preview.style.display = 'none';
+  recorded.style.display = 'none';
+
+  revokeRecordedURL();
+  state.recording.currentBlob = null;
+
+  document.getElementById('record-btn').style.display = 'inline-block';
+  document.getElementById('rerecord-btn').style.display = 'none';
+  document.getElementById('save-recording-btn').style.display = 'none';
+
+  const status = document.getElementById('recording-status');
+  status.textContent = 'Ready to record';
+  status.className = 'recording-status ready';
+
+  document.getElementById('recording-error').style.display = 'none';
+  document.getElementById('video-upload-fallback').style.display = 'none';
+  document.getElementById('upload-progress').style.display = 'none';
+
+  const fileInput = document.getElementById('video-file-input');
+  if (fileInput) fileInput.value = '';
+
+  const uploadBtn = document.getElementById('upload-save-btn');
+  if (uploadBtn) {
+    uploadBtn.style.display = 'none';
+    uploadBtn.textContent = 'Use this upload';
+  }
+
+  const recordingInstructions = document.createElement('div');
+  recordingInstructions.className = 'info-box important';
+  recordingInstructions.id = 'recording-size-warning';
+  recordingInstructions.innerHTML = `
+  <strong>📹 Recording Guidelines</strong>
+  <ul style="margin: 8px 0 0 20px; text-align: left;">
+    <li><strong>Duration:</strong> Keep recordings between 30-60 seconds</li>
+    <li><strong>File size:</strong> Recordings over 45 seconds may fail to upload</li>
+    <li><strong>Language:</strong> Use ASL if you know it, otherwise spoken English</li>
+    <li><strong>Can't record?</strong> Use the "Upload a Recording" option below</li>
+  </ul>
+`;
+
+  const recordingContent = document.getElementById('recording-content');
+  const recordingControls = recordingContent ? recordingContent.querySelector('.recording-controls') : null;
+  if (recordingControls && recordingControls.parentNode && !document.getElementById('recording-size-warning')) {
+    recordingControls.parentNode.insertBefore(recordingInstructions, recordingControls);
+  }
+
+  const requiredTextRec = 'This task is required for study completion.';
+  const etaRec = (TASKS['ID'] && TASKS['ID'].estMinutes) ? `${TASKS['ID'].estMinutes} minutes` : 'a few minutes';
+  const reqsRec = (TASKS['ID'] && TASKS['ID'].requirements) || '—';
+
+  const instructionBox = document.getElementById('task-instructions');
+  if (instructionBox) {
+    document.getElementById('task-title').textContent = TASKS['ID'].name;
+    instructionBox.innerHTML = `
+      <div class="info-box friendly-tip" style="margin-bottom:10px;">
+        <strong>⚠️ Ready to Start ${TASKS['ID'].name}?</strong>
+        <ul style="margin:8px 0 0 20px; text-align:left;">
+          <li>${requiredTextRec}</li>
+          <li>Having problems? Email us instead of skipping</li>
+          <li>Estimated time: <strong>${etaRec}</strong></li>
+          <li>Requirements/tips: <em>${reqsRec}</em></li>
+        </ul>
+      </div>
+    `;
+  }
+}
+
+function showRecordingError(html, showFallback = true) {
+  const box = document.getElementById('recording-error');
+  if (!box) return;
+  box.style.display = 'block';
+  box.innerHTML = html;
+  if (showFallback) {
+    const fb = document.getElementById('video-upload-fallback');
+    if (fb) fb.style.display = 'block';
+  }
+}
+
+export function enhanceUploadFallback(state, saveRecordingFn) {
+  const fallbackDiv = document.getElementById('video-upload-fallback');
+  if (fallbackDiv) {
+    fallbackDiv.innerHTML = `
+    <h3>📁 Upload a Recording Instead</h3>
+    <div class="info-box helpful" style="margin: 15px 0;">
+      <strong>Upload Instructions:</strong>
+      <ol style="margin: 8px 0 0 20px; text-align: left;">
+        <li>Record a 30-60 second video/audio on your device</li>
+        <li>Accepted formats: MP4, MOV, WebM (video) or MP3, M4A, WAV (audio)</li>
+        <li>Maximum size: 50MB for MP4/MOV, 40MB for WebM, 25MB for audio</li>
+        <li>Select your file below</li>
+      </ol>
+    </div>
+    <input type="file"
+           id="video-file-input"
+           accept="video/mp4,video/quicktime,video/webm,video/*,audio/mp3,audio/mpeg,audio/m4a,audio/wav,audio/*,.mp4,.mov,.webm,.mp3,.m4a,.wav"
+           style="margin: 15px 0; padding: 10px; border: 2px solid var(--gray-300); border-radius: 8px; width: 100%;" />
+    <div id="file-info" style="margin: 10px 0; font-weight: bold;"></div>
+    <div class="button-group">
+      <button class="button success" id="upload-save-btn" style="display:none;">Upload This File</button>
+    </div>
+    <p style="font-size: 14px; color: var(--text-secondary); margin-top: 10px;">
+      💡 Tips: Use Camera app for video (iPhone/Android) or Voice Memos for audio (iPhone) or Voice Recorder (Android)
+    </p>
+  `;
+  }
+  bindUploadFallback(state, saveRecordingFn);
+}
+
+function bindUploadFallback(state, saveRecordingFn) {
+  const input = document.getElementById('video-file-input');
+  const btn = document.getElementById('upload-save-btn');
+  const info = document.getElementById('file-info');
+  if (!input || !btn || !info) return;
+
+  input.addEventListener('change', () => {
+    const f = input.files && input.files[0];
+    if (!f) return;
+
+    if (!f.type.startsWith('video/') && !f.type.startsWith('audio/')) {
+      alert('Please select a video or audio file');
+      input.value = '';
+      info.textContent = '';
+      btn.style.display = 'none';
+      return;
+    }
+
+    let format = 'audio';
+    if (f.type.includes('mp4') || f.name.toLowerCase().endsWith('.mp4')) format = 'mp4';
+    else if (f.type.includes('quicktime') || f.name.toLowerCase().endsWith('.mov')) format = 'mov';
+    else if (f.type.includes('webm') || f.name.toLowerCase().endsWith('.webm')) format = 'webm';
+    else if (f.type.startsWith('video/')) format = 'other-video';
+
+    const sizeLimits = { mp4: 50, mov: 50, webm: 40, 'other-video': 40, audio: 25 };
+    const maxMB = sizeLimits[format];
+    const sizeMB = f.size / (1024 * 1024);
+    if (sizeMB > maxMB) {
+      alert(`File too large: ${sizeMB.toFixed(1)}MB. Maximum for ${format.toUpperCase()} is ${maxMB}MB.`);
+      input.value = '';
+      info.textContent = '';
+      btn.style.display = 'none';
+      return;
+    }
+
+    state.recording.currentBlob = f;
+    info.textContent = `${f.name} (${sizeMB.toFixed(1)}MB)`;
+    btn.style.display = 'inline-block';
+  });
+
+  btn.addEventListener('click', saveRecordingFn);
+}
+
+export function bindRecordingSkips(showSkipDialog) {
+  const btn1 = document.getElementById('skip-recording-btn');
+  if (btn1) btn1.addEventListener('click', () => showSkipDialog('ID'));
+}
+
+function startRecordingTimer(state) {
+  const timer = document.getElementById('recording-timer');
+  timer.style.display = 'block';
+  let seconds = 0;
+  state.recording.recordingStart = Date.now();
+  state.recording._timer = setInterval(() => {
+    seconds++;
+    const mins = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    timer.textContent = `${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+  }, 1000);
+}
+
+function stopRecordingTimer(state) {
+  clearInterval(state.recording._timer);
+  const t = document.getElementById('recording-timer');
+  if (t) t.style.display = 'none';
+  if (state.recording.recordingStart) {
+    state.recording.recordingDuration = Date.now() - state.recording.recordingStart;
+  }
+}
+
+export async function toggleRecording(state) {
+  const btn = document.getElementById('record-btn');
+  const status = document.getElementById('recording-status');
+  const preview = document.getElementById('video-preview');
+  if (!state.recording.mediaRecorder) {
+    if (!state.recording.stream) await startPreview(state);
+    if (!state.recording.stream) return;
+    let mimeType;
+    if (state.recording.isVideoMode) {
+      mimeType = MediaRecorder.isTypeSupported('video/webm;codecs=vp9') ? 'video/webm;codecs=vp9' :
+        MediaRecorder.isTypeSupported('video/webm;codecs=vp8') ? 'video/webm;codecs=vp8' : 'video/webm';
+    } else {
+      mimeType = MediaRecorder.isTypeSupported('audio/webm;codecs=opus') ? 'audio/webm;codecs=opus' : 'audio/webm';
+    }
+    state.recording.chunks = [];
+    state.recording.mediaRecorder = new MediaRecorder(state.recording.stream, { mimeType });
+    state.recording.mediaRecorder.ondataavailable = e => {
+      if (e.data && e.data.size > 0) state.recording.chunks.push(e.data);
+    };
+    state.recording.mediaRecorder.onstop = () => {
+      const blob = new Blob(state.recording.chunks, { type: mimeType });
+      state.recording.currentBlob = blob;
+      revokeRecordedURL();
+      const recordedEl = document.getElementById('recorded-video');
+      if (state.recording.isVideoMode) {
+        recordedEl.src = URL.createObjectURL(blob);
+        recordedEl.style.display = 'block';
+        preview.style.display = 'none';
+      } else {
+        const audioPlayer = document.createElement('audio');
+        audioPlayer.id = 'recorded-audio';
+        audioPlayer.controls = true;
+        audioPlayer.src = URL.createObjectURL(blob);
+        const container = recordedEl.parentElement;
+        const existing = document.getElementById('recorded-audio');
+        if (existing) existing.remove();
+        container.insertBefore(audioPlayer, recordedEl);
+        recordedEl.style.display = 'none';
+      }
+      document.getElementById('record-btn').style.display = 'none';
+      document.getElementById('rerecord-btn').style.display = 'inline-block';
+      document.getElementById('save-recording-btn').style.display = 'inline-block';
+      status.textContent = '✅ Recording complete! Ready to save.';
+      status.className = 'recording-status recorded';
+      state.recording.mediaRecorder = null;
+    };
+  }
+  if (state.recording.mediaRecorder && state.recording.mediaRecorder.state === 'recording') {
+    state.recording.mediaRecorder.stop();
+    btn.textContent = 'Start Recording';
+    btn.className = 'button danger';
+    stopRecordingTimer(state);
+  } else if (state.recording.mediaRecorder) {
+    state.recording.mediaRecorder.start();
+    startRecordingTimer(state);
+    btn.textContent = 'Stop Recording';
+    btn.className = 'button danger';
+    status.textContent = state.recording.isVideoMode ? '🔴 Recording video...' : '🎤 Recording audio...';
+    status.className = 'recording-status recording';
+  }
+}
+
+export async function reRecord(state) {
+  await cleanupRecording(state, true);
+  updateRecordingImage(state);
+  if (window.isSecureContext) startPreview(state);
+}
+
+export async function saveRecording(state, sendToSheets, completeTask) {
+  if (!state.recording.currentBlob) {
+    alert('Please record or upload a recording first.');
+    return;
+  }
+
+  const saveBtn = document.getElementById('save-recording-btn');
+  const originalText = saveBtn.textContent;
+  saveBtn.disabled = true;
+  saveBtn.textContent = 'Processing...';
+
+  const status = document.getElementById('recording-status');
+  status.textContent = '⚙️ Processing recording...';
+  status.className = 'recording-status recording';
+
+  const uploadProgress = document.getElementById('upload-progress');
+  uploadProgress.style.display = 'block';
+
+  const recType = state.recording.isVideoMode ? 'video'
+    : (state.recording.currentBlob && state.recording.currentBlob.type && state.recording.currentBlob.type.startsWith('audio') ? 'audio' : 'video');
+
+  sendToSheets({
+    action: 'image_recorded',
+    sessionCode: state.sessionCode,
+    imageNumber: state.recording.currentImage + 1,
+    timestamp: new Date().toISOString(),
+    recordingType: recType
+  });
+
+  sendToSheets({
+    action: 'video_recorded',
+    sessionCode: state.sessionCode,
+    imageNumber: state.recording.currentImage + 1,
+    timestamp: new Date().toISOString(),
+    recordingType: recType
+  });
+
+  try {
+    const uploadResult = await uploadVideoToDrive(
+      state.recording.currentBlob,
+      state.sessionCode,
+      state.recording.currentImage + 1,
+      sendToSheets
+    );
+
+    if (uploadResult.success) {
+      state.recording.recordings.push({
+        image: state.recording.currentImage + 1,
+        blob: state.recording.currentBlob,
+        timestamp: new Date().toISOString(),
+        driveFileId: uploadResult.fileId,
+        driveFileUrl: uploadResult.fileUrl,
+        filename: uploadResult.filename,
+        uploadMethod: uploadResult.uploadMethod,
+        recordingType: state.recording.isVideoMode ? 'video' : 'audio',
+        mimeType: state.recording.currentBlob.type
+      });
+
+      const logData = {
+        action: 'image_recorded_and_uploaded',
+        sessionCode: state.sessionCode,
+        imageNumber: state.recording.currentImage + 1,
+        driveFileId: uploadResult.fileId,
+        filename: uploadResult.filename,
+        timestamp: new Date().toISOString(),
+        deviceType: state.isMobile ? 'mobile/tablet' : 'desktop',
+        uploadMethod: uploadResult.uploadMethod,
+        fileSize: Math.round(state.recording.currentBlob.size / 1024),
+        uploadStatus: 'success',
+        recordingType: state.recording.isVideoMode ? 'video' : 'audio',
+        mimeType: state.recording.currentBlob.type
+      };
+
+      sendToSheets(logData);
+
+      sendToSheets({
+        action: 'log_video_upload',
+        sessionCode: state.sessionCode,
+        imageNumber: state.recording.currentImage + 1,
+        filename: uploadResult.filename,
+        fileId: uploadResult.fileId,
+        fileUrl: uploadResult.fileUrl,
+        fileSize: Math.round(state.recording.currentBlob.size / 1024),
+        uploadTime: new Date().toISOString(),
+        uploadMethod: uploadResult.uploadMethod,
+        uploadStatus: 'success',
+        recordingType: state.recording.isVideoMode ? 'video' : 'audio',
+        mimeType: state.recording.currentBlob.type
+      });
+
+      status.textContent = `✅ Upload complete via ${uploadResult.uploadMethod}!`;
+      status.className = 'recording-status recorded';
+      uploadProgress.style.display = 'none';
+
+      setTimeout(() => {
+        if (state.recording.currentImage === 0) {
+          state.recording.currentImage = 1;
+          updateRecordingImage(state);
+          if (window.isSecureContext) startPreview(state);
+        } else {
+          completeTask('ID');
+        }
+      }, 1000);
+    } else {
+      throw new Error(uploadResult.error || 'Upload failed');
+    }
+  } catch (error) {
+    console.error('Upload error:', error);
+
+    sendToSheets({
+      action: 'log_video_upload_error',
+      sessionCode: state.sessionCode,
+      imageNumber: state.recording.currentImage + 1,
+      error: error.message,
+      timestamp: new Date().toISOString(),
+      deviceType: state.isMobile ? 'mobile/tablet' : 'desktop',
+      attemptedMethod: 'drive',
+      recordingType: state.recording.isVideoMode ? 'video' : 'audio',
+      mimeType: state.recording.currentBlob.type
+    });
+
+    status.textContent = '⚠️ Upload failed. Retrying...';
+    status.className = 'recording-status recording';
+    enqueueFailedUpload(state, state.recording.currentBlob, state.sessionCode, state.recording.currentImage + 1, sendToSheets, completeTask);
+  } finally {
+    saveBtn.disabled = false;
+    saveBtn.textContent = originalText;
+  }
+}
+
+export async function retryVideoUpload(state, sendToSheets, completeTask) {
+  document.getElementById('recording-error').style.display = 'none';
+  await saveRecording(state, sendToSheets, completeTask);
+}
+
+function enqueueFailedUpload(state, blob, sessionCode, imageNumber, sendToSheets, completeTask) {
+  state.uploadQueue.push({ blob, sessionCode, imageNumber, attempts: 0 });
+  processUploadQueue(state, sendToSheets, completeTask);
+}
+
+async function processUploadQueue(state, sendToSheets, completeTask) {
+  if (state.processingUpload || state.uploadQueue.length === 0) return;
+  state.processingUpload = true;
+  const item = state.uploadQueue[0];
+  try {
+    const uploadResult = await uploadVideoToDrive(item.blob, item.sessionCode, item.imageNumber, sendToSheets);
+    if (uploadResult.success) {
+      handleUploadSuccess(state, uploadResult, item.imageNumber, item.blob, sendToSheets, completeTask);
+      state.uploadQueue.shift();
+    } else {
+      throw new Error(uploadResult.error || 'Upload failed');
+    }
+  } catch (err) {
+    item.attempts++;
+    if (item.attempts < 3) {
+      setTimeout(() => {
+        state.processingUpload = false;
+        processUploadQueue(state, sendToSheets, completeTask);
+      }, 5000 * item.attempts);
+      return;
+    }
+    state.uploadQueue.shift();
+    showUploadError(state, err, item.imageNumber, item.blob, sendToSheets);
+  }
+  state.processingUpload = false;
+  if (state.uploadQueue.length > 0) processUploadQueue(state, sendToSheets, completeTask);
+}
+
+function handleUploadSuccess(state, uploadResult, imageNumber, blob, sendToSheets, completeTask) {
+  state.recording.recordings.push({
+    image: imageNumber,
+    blob,
+    timestamp: new Date().toISOString(),
+    driveFileId: uploadResult.fileId,
+    driveFileUrl: uploadResult.fileUrl,
+    filename: uploadResult.filename,
+    uploadMethod: uploadResult.uploadMethod,
+    recordingType: state.recording.isVideoMode ? 'video' : 'audio',
+    mimeType: blob.type
+  });
+
+  const logData = {
+    action: 'image_recorded_and_uploaded',
+    sessionCode: state.sessionCode,
+    imageNumber,
+    driveFileId: uploadResult.fileId,
+    filename: uploadResult.filename,
+    timestamp: new Date().toISOString(),
+    deviceType: state.isMobile ? 'mobile/tablet' : 'desktop',
+    uploadMethod: uploadResult.uploadMethod,
+    fileSize: Math.round(blob.size / 1024),
+    uploadStatus: 'success',
+    recordingType: state.recording.isVideoMode ? 'video' : 'audio',
+    mimeType: blob.type
+  };
+  sendToSheets(logData);
+  sendToSheets({
+    action: 'log_video_upload',
+    sessionCode: state.sessionCode,
+    imageNumber,
+    filename: uploadResult.filename,
+    fileId: uploadResult.fileId,
+    fileUrl: uploadResult.fileUrl,
+    fileSize: Math.round(blob.size / 1024),
+    uploadTime: new Date().toISOString(),
+    uploadMethod: uploadResult.uploadMethod,
+    uploadStatus: 'success',
+    recordingType: state.recording.isVideoMode ? 'video' : 'audio',
+    mimeType: blob.type
+  });
+
+  const status = document.getElementById('recording-status');
+  status.textContent = `✅ Upload complete via ${uploadResult.uploadMethod}!`;
+  status.className = 'recording-status recorded';
+  document.getElementById('upload-progress').style.display = 'none';
+
+  setTimeout(() => {
+    if (imageNumber === 1 && state.recording.currentImage === 0) {
+      state.recording.currentImage = 1;
+      updateRecordingImage(state);
+      if (window.isSecureContext) startPreview(state);
+    } else {
+      completeTask('ID');
+    }
+  }, 1000);
+}
+
+function showUploadError(state, error, imageNumber, blob, sendToSheets) {
+  sendToSheets({
+    action: 'log_video_upload_error',
+    sessionCode: state.sessionCode,
+    imageNumber,
+    error: error.message,
+    timestamp: new Date().toISOString(),
+    deviceType: state.isMobile ? 'mobile/tablet' : 'desktop',
+    attemptedMethod: 'drive',
+    recordingType: state.recording.isVideoMode ? 'video' : 'audio',
+    mimeType: blob.type
+  });
+
+  const uploadProgress = document.getElementById('upload-progress');
+  uploadProgress.style.display = 'none';
+  const errorDiv = document.getElementById('recording-error');
+  errorDiv.style.display = 'block';
+  errorDiv.innerHTML = `
+      <strong>Upload failed</strong>
+      <p style="margin-top: 6px;">Error: ${error.message}. You can try again or continue without uploading. The video is saved locally in your browser.</p>
+      <div class="button-group" style="margin-top: 10px;"><button class="button" onclick="retryVideoUpload()">Try Again</button><button class="button secondary" onclick="continueWithoutUpload()">Continue Without Upload</button></div>`;
+  const status = document.getElementById('recording-status');
+  status.textContent = '❌ Upload failed';
+  status.className = 'recording-status ready';
+}
+
+export function cleanupRecording(state, keepPreviewUI = false) {
+  return new Promise(resolve => {
+    try {
+      if (state.recording.mediaRecorder && state.recording.mediaRecorder.state !== 'inactive') {
+        state.recording.mediaRecorder.addEventListener('stop', () => resolve(), { once: true });
+        try { state.recording.mediaRecorder.stop(); } catch (e) { resolve(); }
+      } else { resolve(); }
+    } catch (e) { resolve(); }
+  }).finally(() => {
+    try { if (state.recording.stream) state.recording.stream.getTracks().forEach(t => t.stop()); } catch (e) {}
+    state.recording.stream = null;
+    state.recording.active = false;
+    state.recording.chunks = [];
+    stopRecordingTimer(state);
+
+    if (!keepPreviewUI) {
+      const preview = document.getElementById('video-preview');
+      if (preview) {
+        if (preview.pause) preview.pause();
+        preview.srcObject = null;
+        preview.style.display = 'none';
+      }
+      const recorded = document.getElementById('recorded-video');
+      if (recorded) {
+        revokeRecordedURL();
+        recorded.style.display = 'none';
+      }
+      state.recording.mediaRecorder = null;
+    }
+  });
+}
+
+export default {
+  startPreview,
+  updateRecordingImage,
+  enhanceUploadFallback,
+  bindRecordingSkips,
+  toggleRecording,
+  reRecord,
+  saveRecording,
+  retryVideoUpload,
+  cleanupRecording
+};


### PR DESCRIPTION
## Summary
- extract video/audio recording logic into `recorder.js`
- delegate recording actions in `main.js` to new module and expose wrappers

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b10b323b288326b9d0cf4c8419d74c