### PR TITLE
feat: send recovery emails

### DIFF
--- a/google-apps-script.gs
+++ b/google-apps-script.gs
@@ -1305,7 +1305,10 @@ function createSession(ss, data) {
       userAgent: data.userAgent || ''
     });
 
-    if (data.email) addEmailReminder(ss, data.sessionCode, data.email);
+    if (data.email) {
+      addEmailReminder(ss, data.sessionCode, data.email);
+      sendRecoveryEmail(data.email, data.sessionCode);
+    }
 
     try {
       var folder = getOrCreateStudyFolder();
@@ -1330,6 +1333,19 @@ function addEmailReminder(ss, sessionCode, email) {
     }
     sheet.appendRow([sessionCode, email || '', '', 0, 'New Session']);
   });
+}
+
+function sendRecoveryEmail(email, sessionCode) {
+  try {
+    var link = 'https://<your-domain>/?recover=' + encodeURIComponent(Utilities.base64Encode(sessionCode));
+    MailApp.sendEmail({
+      to: email,
+      subject: 'Resume your session',
+      htmlBody: 'Click <a href="' + link + '">resume link</a> or use code ' + sessionCode
+    });
+  } catch (e) {
+    handleError(e);
+  }
 }
 
 function resumeSession(ss, data) {


### PR DESCRIPTION
## Summary
- add sendRecoveryEmail Apps Script helper to send MailApp resume link
- email recovery link when a session is created

## Testing
- `npm run lint`
- `SHEETS_URL=http://example.com CLOUDINARY_CLOUD_NAME=foo CLOUDINARY_UPLOAD_PRESET=bar npm start`

------
https://chatgpt.com/codex/tasks/task_e_68b10e366bc8832682d66d6aa96b5963