### PR TITLE
Disable image description task

### DIFF
--- a/google-apps-script.gs
+++ b/google-apps-script.gs
@@ -2125,14 +2125,12 @@ function getRequiredTasksForSession_(ss, sessionCode) {
     'Mental Rotation Task',
     'ASL Comprehension Test',
     'Spatial Navigation',
-    'Image Description',
+    // 'Image Description', temporarily disabled
     'Demographics Survey'
   ];
   if (!isMobile) required.splice(3, 0, 'Virtual Campus Navigation');
 
-  if (String(consentStatus).toLowerCase() === 'declined') {
-    required = required.filter(function (t) { return t !== 'Image Description'; });
-  }
+  // Image Description task is disabled; consent filtering not needed
 
   var progress = ss.getSheetByName('Task Progress').getDataRange().getValues();
   var aslctOptional = false;
@@ -2174,8 +2172,7 @@ function updateCompletedTasksCount(ss, sessionCode) {
 
       var isCompleted = (eventType === 'Completed');
       var isValidSkip = (eventType === 'Skipped' && (
-        (taskName === 'ASL Comprehension Test' && details.indexOf('does not know asl') !== -1) ||
-        (taskName === 'Image Description'      && details.indexOf('video consent declined') !== -1)
+        (taskName === 'ASL Comprehension Test' && details.indexOf('does not know asl') !== -1)
       ));
 
       if ((isCompleted || isValidSkip) && requiredSet[taskName]) {

--- a/main.js
+++ b/main.js
@@ -20,7 +20,8 @@
     "ASLCT": { name: "ASL Comprehension Test", description: "For ASL users only", url: "https://vl2portal.gallaudet.edu/assessment/", type: "external", canSkip: true, estMinutes: 15, requirements: "ASL users; stable connection", skilled: true },
     "VCN": { name: "Virtual Campus Navigation", description: "Virtual SILC Test of Navigation (SILCton)", url: "http://www.virtualsilcton.com/study/753798747", type: "external", canSkip: true, estMinutes: 20, requirements: "Desktop/laptop; keyboard (WASD) & mouse", skilled: true },
     "SN": { name: "Spatial Navigation", description: "Choose the first step from the player to the stop sign (embedded below)", type: "embed", embedUrl: "https://melodyfschwenk.github.io/spatial-navigation-web/", canSkip: true, estMinutes: 8, requirements: "Arrow keys", skilled: true },
-    "ID": { name: "Image Description", description: "Record two short videos describing images (or upload if recording is unavailable).", type: "recording", canSkip: true, estMinutes: 2, requirements: "Camera & microphone or video upload" },
+    // Temporarily disabled
+    "ID": { name: "Image Description", description: "Record two short videos describing images (or upload if recording is unavailable).", type: "recording", canSkip: true, estMinutes: 2, requirements: "Camera & microphone or video upload", disabled: true },
     "DEMO": { name: "Demographics Survey", description: "Background information & payment", url: "https://gallaudet.iad1.qualtrics.com/jfe/form/SV_8GJcoF3hkHoP8BU", type: "external", estMinutes: 6, requirements: "None" }
   };
   function getStandardTaskName(taskCode) {
@@ -35,8 +36,8 @@
     };
     return mapping[taskCode] || (TASKS[taskCode] ? TASKS[taskCode].name : void 0) || taskCode;
   }
-  var DESKTOP_TASKS = ["RC", "MRT", "ASLCT", "VCN", "SN", "ID"];
-  var MOBILE_TASKS = ["RC", "MRT", "ASLCT", "SN", "ID"];
+  var DESKTOP_TASKS = ["RC", "MRT", "ASLCT", "VCN", "SN"];
+  var MOBILE_TASKS = ["RC", "MRT", "ASLCT", "SN"];
   function mulberry32(a) {
     return function() {
       a |= 0;

--- a/src/tasks.js
+++ b/src/tasks.js
@@ -4,7 +4,8 @@ export const TASKS = {
   'ASLCT':{ name:'ASL Comprehension Test',   description:'For ASL users only',                                                 url:'https://vl2portal.gallaudet.edu/assessment/', type:'external', canSkip:true, estMinutes:15, requirements:'ASL users; stable connection', skilled:true },
   'VCN':  { name:'Virtual Campus Navigation', description:'Virtual SILC Test of Navigation (SILCton)',                         url:'http://www.virtualsilcton.com/study/753798747', type:'external', canSkip:true, estMinutes:20, requirements:'Desktop/laptop; keyboard (WASD) & mouse', skilled:true },
   'SN':   { name:'Spatial Navigation',        description:'Choose the first step from the player to the stop sign (embedded below)', type:'embed',   embedUrl:'https://melodyfschwenk.github.io/spatial-navigation-web/', canSkip:true, estMinutes:8,  requirements:'Arrow keys',                     skilled:true },
-  'ID':   { name:'Image Description',        description:'Record two short videos describing images (or upload if recording is unavailable).', type:'recording', canSkip:true, estMinutes:2, requirements:'Camera & microphone or video upload' },
+  // Temporarily disabled
+  'ID':   { name:'Image Description',        description:'Record two short videos describing images (or upload if recording is unavailable).', type:'recording', canSkip:true, estMinutes:2, requirements:'Camera & microphone or video upload', disabled:true },
   'DEMO': { name:'Demographics Survey',      description:'Background information & payment', url:'https://gallaudet.iad1.qualtrics.com/jfe/form/SV_8GJcoF3hkHoP8BU', type:'external', estMinutes:6, requirements:'None' }
 };
 
@@ -21,8 +22,8 @@ export function getStandardTaskName(taskCode) {
   return mapping[taskCode] || (TASKS[taskCode] ? TASKS[taskCode].name : undefined) || taskCode;
 }
 
-export const DESKTOP_TASKS = ['RC', 'MRT', 'ASLCT', 'VCN', 'SN', 'ID'];
-export const MOBILE_TASKS = ['RC', 'MRT', 'ASLCT', 'SN', 'ID'];
+export const DESKTOP_TASKS = ['RC', 'MRT', 'ASLCT', 'VCN', 'SN'];
+export const MOBILE_TASKS = ['RC', 'MRT', 'ASLCT', 'SN'];
 
 export function mulberry32(a) {
   return function() {


### PR DESCRIPTION
## Summary
- disable Image Description task by removing it from default task sequences
- mark Image Description metadata as disabled
- drop Image Description from required tasks in the Apps Script

## Testing
- `npm run lint`
- `npm run build`
- `npm start` *(fails: Missing configuration values: SHEETS_URL, CLOUDINARY_CLOUD_NAME, CLOUDINARY_UPLOAD_PRESET)*

------
https://chatgpt.com/codex/tasks/task_e_68b10e5c31148326aeaf0803b224c356