### PR TITLE
Hide broken resume button and clarify session code usage

### DIFF
--- a/index.html
+++ b/index.html
@@ -304,9 +304,9 @@
     <div>
       <h4 style="margin-bottom: 8px; font-weight: 600;">How it works</h4>
       <ul style="margin: 8px 0 0 0; padding-left: 16px; color: inherit;">
-        <li>Get your unique resume code to save progress</li>
+        <li>Get your unique session code in case a glitch occurs</li>
         <li>Complete tasks at your own pace</li>
-        <li>Return anytime using your code</li>
+        <li>Share your code with support if something goes wrong</li>
       </ul>
     </div>
   </div>
@@ -340,14 +340,14 @@
       </div>
     </div>
 
-    <div class="card">
+    <div class="card" style="display: none;">
       <div style="text-align: center;">
         <div style="font-size: 48px; margin-bottom: 16px;">🔄</div>
         <h3 style="margin-bottom: 12px; font-size: 20px;">Returning Participant</h3>
         <p style="color: var(--text-secondary); margin-bottom: 20px;">
           Continue where you left off with your code
         </p>
-        <button class="button secondary" onclick="showScreen('returning-participant')">
+        <button class="button secondary" onclick="showScreen('returning-participant')" style="display: none;">
           Resume Session →
         </button>
       </div>
@@ -418,17 +418,17 @@
       </div>
 
       <!-- Returning Participant -->
-      <div class="screen" id="returning-participant">
+      <div class="screen" id="returning-participant" style="display: none;">
         <h2>Resume Your Session</h2>
         <p style="color: var(--text-secondary); margin-bottom: 30px;">Enter your 8-character code to continue</p>
 
         <div class="form-group">
-          <label for="resume-code">Resume Code</label>
+          <label for="resume-code">Session Code</label>
           <input type="text" id="resume-code" maxlength="8" placeholder="ABC12345" style="text-transform: uppercase; font-family: monospace; font-size: 24px; letter-spacing: 2px; text-align: center;" />
         </div>
 
         <div class="button-group">
-          <button class="button primary" onclick="resumeSession()">Resume Session</button>
+          <button class="button primary" onclick="resumeSession()" style="display: none;">Resume Session</button>
           <button class="button secondary" onclick="showScreen('welcome-screen')">Back</button>
         </div>
       </div>
@@ -437,18 +437,18 @@
       <div class="screen" id="session-created">
         <h2>✅ Session Created Successfully!</h2>
         <div class="code-display">
-          <p>Your Resume Code:</p>
+          <p>Your Session Code:</p>
           <div class="code" id="display-code">ABC12345</div>
         <button class="button optional outline" onclick="copyCode(this)">📋 Copy Code</button>
         <button class="button optional outline" onclick="copyRecoveryLink(this)">🔗 Copy Recovery Link</button>
-          <p style="font-size: 14px; margin-top: 15px;">Save this code to resume anytime</p>
+          <p style="font-size: 14px; margin-top: 15px;">Copy this code in case of a glitch so we can verify your session</p>
         </div>
 
         <div class="info-box important">
           <strong>⚠️ Important: Save Your Code!</strong>
           <ul style="margin: 10px 0 0 20px; text-align: left;">
             <li>Write down or screenshot your code</li>
-            <li>Use this code to continue from any device</li>
+            <li>Share this code with support if something goes wrong</li>
             <li>Progress saves automatically after each task</li>
           </ul>
         </div>
@@ -707,7 +707,7 @@
         <button class="button optional outline" onclick="copyCode(this)">📋 Copy Code</button>
         <button class="button optional outline" onclick="copyRecoveryLink(this)">🔗 Copy Recovery Link</button>
       </div>
-      <p style="font-size: 14px; color: var(--text-secondary); margin-top: 20px;">Return anytime to complete remaining tasks.</p>
+      <p style="font-size: 14px; color: var(--text-secondary); margin-top: 20px;">Copy this code in case of a glitch so support can verify your progress.</p>
       <button class="button" onclick="location.reload()">Exit Study</button>
     </div>
   </div>

--- a/main.js
+++ b/main.js
@@ -1317,7 +1317,7 @@ Session code: ${state.sessionCode || ""}`);
         warning.innerHTML = `
   <strong>\u{1F4F1} Mobile or Tablet?</strong>
   <p style="margin-top: 10px;">
-    Some tasks work best on a computer. You can pause now and resume later with your code.
+    Some tasks work best on a computer. You can pause now. Copy your session code in case of a glitch so support can verify your progress.
   </p>
   <ul style="margin: 10px 0 0 20px; text-align: left;">
     <li><strong>Virtual Campus Navigation</strong> needs keyboard controls (WASD/arrow keys)</li>
@@ -1408,7 +1408,7 @@ Session code: ${state.sessionCode || ""}`);
     }
     if (isMobileDevice()) {
       const proceed = confirm(
-        "You are on a phone or tablet.\n\nA computer is preferred for the best experience, but you can continue now.\nYou can also pause and resume later on a computer using your resume code.\n\nContinue on this device?"
+        "You are on a phone or tablet.\n\nA computer is preferred for the best experience, but you can continue now.\nIf you encounter a glitch, share your session code with support while we fix the resume feature.\n\nContinue on this device?"
       );
       if (!proceed) return;
     }
@@ -1451,7 +1451,7 @@ Session code: ${state.sessionCode || ""}`);
     const input = codeFromLink || document.getElementById("resume-code").value;
     const code = input.trim().toUpperCase();
     if (!CODE_REGEX.test(code)) {
-      alert("Please enter your 8-character resume code");
+      alert("Please enter your 8-character session code");
       return;
     }
     try {

--- a/src/main.js
+++ b/src/main.js
@@ -414,7 +414,7 @@ function init() {
       warning.innerHTML = `
   <strong>📱 Mobile or Tablet?</strong>
   <p style="margin-top: 10px;">
-    Some tasks work best on a computer. You can pause now and resume later with your code.
+    Some tasks work best on a computer. You can pause now. Copy your session code in case of a glitch so support can verify your progress.
   </p>
   <ul style="margin: 10px 0 0 20px; text-align: left;">
     <li><strong>Virtual Campus Navigation</strong> needs keyboard controls (WASD/arrow keys)</li>
@@ -522,7 +522,7 @@ function showScreen(screenId) {
         const proceed = confirm(
           'You are on a phone or tablet.\n\n' +
           'A computer is preferred for the best experience, but you can continue now.\n' +
-          'You can also pause and resume later on a computer using your resume code.\n\n' +
+          'If you encounter a glitch, share your session code with support while we fix the resume feature.\n\n' +
           'Continue on this device?'
         );
         if (!proceed) return;
@@ -572,7 +572,7 @@ function showScreen(screenId) {
       async function resumeSession(codeFromLink) {
         const input = codeFromLink || document.getElementById('resume-code').value;
         const code = input.trim().toUpperCase();
-        if (!CODE_REGEX.test(code)) { alert('Please enter your 8-character resume code'); return; }
+        if (!CODE_REGEX.test(code)) { alert('Please enter your 8-character session code'); return; }
       try {
         const res = await fetch(CONFIG.SHEETS_URL, {
           method: 'POST',


### PR DESCRIPTION
## Summary
- Hide manual resume session UI and button while feature is repaired
- Update instructions to copy session code only for troubleshooting
- Adjust mobile warning and prompts to mention session code for glitches

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1974e354083269f9cd2491811b06e