### PR TITLE
chore: remove automatic session resume email

### DIFF
--- a/google-apps-script.gs
+++ b/google-apps-script.gs
@@ -1307,7 +1307,6 @@ function createSession(ss, data) {
 
     if (data.email) {
       addEmailReminder(ss, data.sessionCode, data.email);
-      sendRecoveryEmail(data.email, data.sessionCode);
     }
 
     try {
@@ -1335,18 +1334,6 @@ function addEmailReminder(ss, sessionCode, email) {
   });
 }
 
-function sendRecoveryEmail(email, sessionCode) {
-  try {
-    var link = 'https://<your-domain>/?recover=' + encodeURIComponent(Utilities.base64Encode(sessionCode));
-    MailApp.sendEmail({
-      to: email,
-      subject: 'Resume your session',
-      htmlBody: 'Click <a href="' + link + '">resume link</a> or use code ' + sessionCode
-    });
-  } catch (e) {
-    handleError(e);
-  }
-}
 
 function resumeSession(ss, data) {
   withDocLock_(function () {


### PR DESCRIPTION
## Summary
- stop automatic email with session resume code in google-apps-script
- eliminate obsolete `sendRecoveryEmail` helper

## Testing
- `npm run lint`
- `SHEETS_URL=foo CLOUDINARY_CLOUD_NAME=foo CLOUDINARY_UPLOAD_PRESET=foo npm start`

------
https://chatgpt.com/codex/tasks/task_e_68b198d1bdb4832697a44a95bce0389d