### PR TITLE
Enable image description task

### DIFF
--- a/main.js
+++ b/main.js
@@ -20,8 +20,7 @@
     "ASLCT": { name: "ASL Comprehension Test", description: "For ASL users only", url: "https://vl2portal.gallaudet.edu/assessment/", type: "external", canSkip: true, estMinutes: 15, requirements: "ASL users; stable connection", skilled: true },
     "VCN": { name: "Virtual Campus Navigation", description: "Virtual SILC Test of Navigation (SILCton)", url: "http://www.virtualsilcton.com/study/753798747", type: "external", canSkip: true, estMinutes: 20, requirements: "Desktop/laptop; keyboard (WASD) & mouse", skilled: true },
     "SN": { name: "Spatial Navigation", description: "Choose the first step from the player to the stop sign (embedded below)", type: "embed", embedUrl: "https://melodyfschwenk.github.io/spatial-navigation-web/", canSkip: true, estMinutes: 8, requirements: "Arrow keys", skilled: true },
-    // Temporarily disabled
-    "ID": { name: "Image Description", description: "Record two short videos describing images (or upload if recording is unavailable).", type: "recording", canSkip: true, estMinutes: 2, requirements: "Camera & microphone or video upload", disabled: true },
+    "ID": { name: "Image Description", description: "Record two short videos describing images (or upload if recording is unavailable).", type: "recording", canSkip: true, estMinutes: 2, requirements: "Camera & microphone or video upload" },
     "DEMO": { name: "Demographics Survey", description: "Background information & payment", url: "https://gallaudet.iad1.qualtrics.com/jfe/form/SV_8GJcoF3hkHoP8BU", type: "external", estMinutes: 6, requirements: "None" }
   };
   function getStandardTaskName(taskCode) {
@@ -36,8 +35,8 @@
     };
     return mapping[taskCode] || (TASKS[taskCode] ? TASKS[taskCode].name : void 0) || taskCode;
   }
-  var DESKTOP_TASKS = ["RC", "MRT", "ASLCT", "VCN", "SN"];
-  var MOBILE_TASKS = ["RC", "MRT", "ASLCT", "SN"];
+  var DESKTOP_TASKS = ["RC", "MRT", "ASLCT", "VCN", "SN", "ID"];
+  var MOBILE_TASKS = ["RC", "MRT", "ASLCT", "SN", "ID"];
   function mulberry32(a) {
     return function() {
       a |= 0;

--- a/src/tasks.js
+++ b/src/tasks.js
@@ -4,8 +4,7 @@ export const TASKS = {
   'ASLCT':{ name:'ASL Comprehension Test',   description:'For ASL users only',                                                 url:'https://vl2portal.gallaudet.edu/assessment/', type:'external', canSkip:true, estMinutes:15, requirements:'ASL users; stable connection', skilled:true },
   'VCN':  { name:'Virtual Campus Navigation', description:'Virtual SILC Test of Navigation (SILCton)',                         url:'http://www.virtualsilcton.com/study/753798747', type:'external', canSkip:true, estMinutes:20, requirements:'Desktop/laptop; keyboard (WASD) & mouse', skilled:true },
   'SN':   { name:'Spatial Navigation',        description:'Choose the first step from the player to the stop sign (embedded below)', type:'embed',   embedUrl:'https://melodyfschwenk.github.io/spatial-navigation-web/', canSkip:true, estMinutes:8,  requirements:'Arrow keys',                     skilled:true },
-  // Temporarily disabled
-  'ID':   { name:'Image Description',        description:'Record two short videos describing images (or upload if recording is unavailable).', type:'recording', canSkip:true, estMinutes:2, requirements:'Camera & microphone or video upload', disabled:true },
+  'ID':   { name:'Image Description',        description:'Record two short videos describing images (or upload if recording is unavailable).', type:'recording', canSkip:true, estMinutes:2, requirements:'Camera & microphone or video upload' },
   'DEMO': { name:'Demographics Survey',      description:'Background information & payment', url:'https://gallaudet.iad1.qualtrics.com/jfe/form/SV_8GJcoF3hkHoP8BU', type:'external', estMinutes:6, requirements:'None' }
 };
 
@@ -22,8 +21,8 @@ export function getStandardTaskName(taskCode) {
   return mapping[taskCode] || (TASKS[taskCode] ? TASKS[taskCode].name : undefined) || taskCode;
 }
 
-export const DESKTOP_TASKS = ['RC', 'MRT', 'ASLCT', 'VCN', 'SN'];
-export const MOBILE_TASKS = ['RC', 'MRT', 'ASLCT', 'SN'];
+export const DESKTOP_TASKS = ['RC', 'MRT', 'ASLCT', 'VCN', 'SN', 'ID'];
+export const MOBILE_TASKS = ['RC', 'MRT', 'ASLCT', 'SN', 'ID'];
 
 export function mulberry32(a) {
   return function() {


### PR DESCRIPTION
## Summary
- Re-enable the Image Description recording task by removing its disabled flag
- Add Image Description to desktop and mobile task sequences
- Rebuild bundled `main.js` artifact

## Testing
- `npm run lint`
- `npm run build`
- `SHEETS_URL=https://example.com CLOUDINARY_CLOUD_NAME=test CLOUDINARY_UPLOAD_PRESET=test npm start`

------
https://chatgpt.com/codex/tasks/task_e_68b1a61b3a448326b5dc7986fe0fc44a