### PR TITLE
Improve mobile consent affirmation on small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,6 +97,22 @@
     .form-group label { display: block; font-weight: 600; margin-bottom: 8px; color: var(--text-primary); }
     .form-group input { width: 100%; padding: 12px; border: 2px solid var(--gray-300); border-radius: 8px; font-size: 16px; transition: border-color 0.3s; }
     .form-group input:focus { outline: none; border-color: var(--primary); }
+    .form-group input[type="checkbox"] {
+      width: 24px;
+      height: 24px;
+      padding: 0;
+      margin: 0;
+      flex-shrink: 0;
+      border: 2px solid var(--gray-300);
+      border-radius: 4px;
+      accent-color: var(--primary);
+    }
+    .form-group.checkbox label {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin: 0;
+    }
     .form-group select { 
   width: 100%; 
   padding: 12px; 
@@ -373,8 +389,8 @@
           <input type="text" id="consent-code" placeholder="e.g., ABC123" />
         </div>
 
-        <div class="form-group">
-          <label style="display: flex; align-items: center; gap: 10px;">
+        <div class="form-group checkbox">
+          <label>
             <input type="checkbox" id="consent-confirm" />
             I have completed the consent form
           </label>


### PR DESCRIPTION
## Summary
- Enlarge consent checkbox for better touch targets
- Align checkbox label with flex layout for improved mobile readability

## Testing
- `npm run lint`
- `npm run build`
- `SHEETS_URL=http://example.com CLOUDINARY_CLOUD_NAME=dummy CLOUDINARY_UPLOAD_PRESET=dummy npm start`

------
https://chatgpt.com/codex/tasks/task_e_68b1b0b2014883268bace9ae0e95e1df