### PR TITLE
refactor: centralize cloudinary config

### DIFF
--- a/main.js
+++ b/main.js
@@ -353,9 +353,6 @@
   }
 
   // src/main.js
-  var CLOUDINARY_CLOUD = "demo";
-  var CLOUDINARY_PRESET = "unsigned";
-  var CLOUDINARY_FOLDER = "spatial-cognition-videos";
   var RECORDING_BYTES_LIMIT = 50 * 1024 * 1024;
   document.querySelectorAll(".support-email").forEach((el) => {
     el.textContent = CONFIG.SUPPORT_EMAIL;
@@ -1767,11 +1764,11 @@ Thank you!`);
     }
     function uploadToCloudinary2(file) {
       return new Promise((resolve, reject) => {
-        const url = `https://api.cloudinary.com/v1_1/${CLOUDINARY_CLOUD}/video/upload`;
+        const url = `https://api.cloudinary.com/v1_1/${CONFIG.CLOUDINARY_CLOUD_NAME}/video/upload`;
         const form = new FormData();
         form.append("file", file, file.name);
-        form.append("upload_preset", CLOUDINARY_PRESET);
-        form.append("folder", CLOUDINARY_FOLDER);
+        form.append("upload_preset", CONFIG.CLOUDINARY_UPLOAD_PRESET);
+        form.append("folder", CONFIG.CLOUDINARY_FOLDER);
         const xhr = new XMLHttpRequest();
         xhr.open("POST", url);
         xhr.upload.onprogress = (e) => {

--- a/src/main.js
+++ b/src/main.js
@@ -19,9 +19,6 @@ import {
 
 // ----- Configuration -----
 /* === MS-RECORDER-CONFIG START === */
-const CLOUDINARY_CLOUD = 'demo';        // your cloud name
-const CLOUDINARY_PRESET = 'unsigned';       // your unsigned preset
-const CLOUDINARY_FOLDER = 'spatial-cognition-videos';
 const RECORDING_BYTES_LIMIT = 50 * 1024 * 1024; // 50 MB limit
 /* === MS-RECORDER-CONFIG END === */
 
@@ -1571,11 +1568,11 @@ function msRecorderInit() {
   function uploadToCloudinary(file) {
     return new Promise((resolve, reject) => {
       // Use video endpoint for both video and audio
-      const url = `https://api.cloudinary.com/v1_1/${CLOUDINARY_CLOUD}/video/upload`;
+      const url = `https://api.cloudinary.com/v1_1/${CONFIG.CLOUDINARY_CLOUD_NAME}/video/upload`;
       const form = new FormData();
       form.append('file', file, file.name);
-      form.append('upload_preset', CLOUDINARY_PRESET);
-      form.append('folder', CLOUDINARY_FOLDER);
+      form.append('upload_preset', CONFIG.CLOUDINARY_UPLOAD_PRESET);
+      form.append('folder', CONFIG.CLOUDINARY_FOLDER);
 
       const xhr = new XMLHttpRequest();
       xhr.open('POST', url);


### PR DESCRIPTION
## Summary
- remove hard-coded Cloudinary constants from the frontend
- reference CONFIG for Cloudinary upload URL and parameters
- rebuild main.js bundle

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b33dd4fffc83269de5e603f710d900