### PR TITLE
Streamline task skipping flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -756,20 +756,6 @@
     </div>
   </div>
   
-<!-- Pre-Skip Modal -->
-<div class="modal" id="pre-skip-modal">
-  <div class="modal-content">
-    <h3>Before you skip, can we help?</h3>
-    <p>This task is important to the study.</p>
-    <div class="button-group">
-      <button class="button primary" id="pre-skip-try-btn">I will try it</button>
-      <button class="button secondary" id="pre-skip-help-btn">Get help by email</button>
-      <button class="button secondary" id="pre-skip-break-btn">Take a break</button>
-      <button class="button skip" id="pre-skip-skip-btn">I still need to skip</button>
-    </div>
-  </div>
-</div>
-
 <!-- Skip Modal -->
 <div class="modal" id="skip-modal">
   <div class="modal-content">

--- a/main.js
+++ b/main.js
@@ -1507,25 +1507,8 @@ Session code: ${state.sessionCode || ""}`);
   var pendingSkipTask = null;
   function showSkipDialog(taskCode) {
     pendingSkipTask = taskCode;
-    const pre = document.getElementById("pre-skip-modal");
-    pre.classList.add("active");
-  }
-  document.getElementById("pre-skip-try-btn").onclick = () => {
-    document.getElementById("pre-skip-modal").classList.remove("active");
-  };
-  document.getElementById("pre-skip-help-btn").onclick = () => {
-    document.getElementById("pre-skip-modal").classList.remove("active");
-    openSupportEmail(pendingSkipTask);
-    sendToSheets({ action: "help_requested", sessionCode: state.sessionCode || "none", task: getStandardTaskName(pendingSkipTask), timestamp: (/* @__PURE__ */ new Date()).toISOString() });
-  };
-  document.getElementById("pre-skip-break-btn").onclick = () => {
-    document.getElementById("pre-skip-modal").classList.remove("active");
-    pauseStudy();
-  };
-  document.getElementById("pre-skip-skip-btn").onclick = () => {
-    document.getElementById("pre-skip-modal").classList.remove("active");
     document.getElementById("skip-modal").classList.add("active");
-  };
+  }
   document.getElementById("skip-help-btn").onclick = () => {
     openSupportEmail(pendingSkipTask);
     sendToSheets({ action: "help_requested", sessionCode: state.sessionCode || "none", task: getStandardTaskName(pendingSkipTask), timestamp: (/* @__PURE__ */ new Date()).toISOString() });

--- a/src/main.js
+++ b/src/main.js
@@ -1274,25 +1274,8 @@ function markEEGScheduled() {
     let pendingSkipTask = null;
     function showSkipDialog(taskCode) {
       pendingSkipTask = taskCode;
-      const pre = document.getElementById('pre-skip-modal');
-      pre.classList.add('active');
-    }
-    document.getElementById('pre-skip-try-btn').onclick = () => {
-      document.getElementById('pre-skip-modal').classList.remove('active');
-    };
-    document.getElementById('pre-skip-help-btn').onclick = () => {
-      document.getElementById('pre-skip-modal').classList.remove('active');
-      openSupportEmail(pendingSkipTask);
-      sendToSheets({ action: 'help_requested', sessionCode: state.sessionCode || 'none', task: getStandardTaskName(pendingSkipTask), timestamp: new Date().toISOString() });
-    };
-    document.getElementById('pre-skip-break-btn').onclick = () => {
-      document.getElementById('pre-skip-modal').classList.remove('active');
-      pauseStudy();
-    };
-    document.getElementById('pre-skip-skip-btn').onclick = () => {
-      document.getElementById('pre-skip-modal').classList.remove('active');
       document.getElementById('skip-modal').classList.add('active');
-    };
+    }
 
     document.getElementById('skip-help-btn').onclick = () => {
       openSupportEmail(pendingSkipTask);


### PR DESCRIPTION
## Summary
- Remove intermediate pre-skip modal and open the skip confirmation directly to reduce prompts.
- Update bundled script to reflect simplified skip logic.

## Testing
- `npm run lint`
- `npm run build`
- `npm start` *(fails: Missing configuration values: SHEETS_URL, CLOUDINARY_CLOUD_NAME, CLOUDINARY_UPLOAD_PRESET)*

------
https://chatgpt.com/codex/tasks/task_e_68b350f3159c8326a9f9b936680b7ab8