### PR TITLE
feat: add honeypot spam filter

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,7 +128,8 @@
   border-color: var(--primary); 
 }
     .form-row { display: grid; grid-template-columns: 1fr 1fr; gap: 15px; }
-    
+    .honeypot { display: none; }
+
     /* Buttons */
     .button {
       background: var(--primary);
@@ -412,6 +413,11 @@
           <input type="email" id="email" placeholder="your.email@example.com" />
         </div>
 
+        <div class="form-group honeypot">
+          <label for="registration-website">Website</label>
+          <input type="text" id="registration-website" name="website" autocomplete="off" tabindex="-1" aria-hidden="true" />
+        </div>
+
         <div class="form-row">
           <div class="form-group">
             <label for="hearing-status">Hearing Status</label>
@@ -446,6 +452,11 @@
         <div class="form-group">
           <label for="resume-code">Session Code</label>
           <input type="text" id="resume-code" maxlength="8" placeholder="ABC12345" style="text-transform: uppercase; font-family: monospace; font-size: 24px; letter-spacing: 2px; text-align: center;" />
+        </div>
+
+        <div class="form-group honeypot">
+          <label for="resume-website">Website</label>
+          <input type="text" id="resume-website" name="website" autocomplete="off" tabindex="-1" aria-hidden="true" />
         </div>
 
         <div class="button-group">

--- a/main.js
+++ b/main.js
@@ -782,6 +782,8 @@ Session code: ${state.sessionCode || ""}`);
     return code;
   }
   function createNewSession() {
+    const honeypot = document.getElementById("registration-website").value.trim();
+    if (honeypot) return;
     const first = document.getElementById("first-initial").value.trim().toUpperCase();
     const last = document.getElementById("last-initial").value.trim().toUpperCase();
     const email = document.getElementById("email").value.trim();
@@ -835,6 +837,10 @@ Session code: ${state.sessionCode || ""}`);
     showScreen("session-created");
   }
   async function resumeSession(codeFromLink) {
+    if (!codeFromLink) {
+      const honeypot = document.getElementById("resume-website").value.trim();
+      if (honeypot) return;
+    }
     const input = codeFromLink || document.getElementById("resume-code").value;
     const code = input.trim().toUpperCase();
     if (!CODE_REGEX.test(code)) {

--- a/server.js
+++ b/server.js
@@ -42,6 +42,18 @@ const server = http.createServer((req, res) => {
   req.on('data', chunk => { body += chunk; });
   req.on('end', async () => {
     try {
+      const data = JSON.parse(body);
+      if (data && data.website) {
+        res.writeHead(400, {
+          'Access-Control-Allow-Origin': '*',
+          'Content-Type': 'application/json'
+        });
+        return res.end(JSON.stringify({ success: false, error: 'Spam detected' }));
+      }
+    } catch (e) {
+      // ignore malformed JSON
+    }
+    try {
       const gsRes = await fetch(process.env.SHEETS_URL, {
         method: 'POST',
         headers: { 'Content-Type': 'text/plain;charset=utf-8' },

--- a/src/main.js
+++ b/src/main.js
@@ -500,6 +500,8 @@ function showScreen(screenId) {
     }
 
     function createNewSession() {
+      const honeypot = document.getElementById('registration-website').value.trim();
+      if (honeypot) return;
       const first = document.getElementById('first-initial').value.trim().toUpperCase();
       const last = document.getElementById('last-initial').value.trim().toUpperCase();
       const email = document.getElementById('email').value.trim();
@@ -561,6 +563,10 @@ function showScreen(screenId) {
     }
 
       async function resumeSession(codeFromLink) {
+        if (!codeFromLink) {
+          const honeypot = document.getElementById('resume-website').value.trim();
+          if (honeypot) return;
+        }
         const input = codeFromLink || document.getElementById('resume-code').value;
         const code = input.trim().toUpperCase();
         if (!CODE_REGEX.test(code)) { alert('Please enter your 8-character session code'); return; }


### PR DESCRIPTION
## Summary
- hide `website` honeypot inputs in registration and resume forms
- block form submissions and proxy requests when the honeypot is filled

## Testing
- `npm run lint`
- `npm run build`
- `npm start` *(fails: Missing configuration values: SHEETS_URL, CLOUDINARY_CLOUD_NAME, CLOUDINARY_UPLOAD_PRESET)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c598166c83269af1a01bf5d4d980