### PR TITLE
Add access log for request IP tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ npm start
 
 Check the console for warnings or errors during startup.
 
+The server records each request's IP address and timestamp to an `access.log` file in the project root. Review this file to monitor repeated visits or unusual access patterns.
+
 ## Environment variables
 
 Create a `.env` file or export these variables before running the server:


### PR DESCRIPTION
## Summary
- log each request's IP, method, and URL to `access.log`
- document access logging in README

## Testing
- `npm run lint`
- `SHEETS_URL=http://example.com CLOUDINARY_CLOUD_NAME=test CLOUDINARY_UPLOAD_PRESET=test npm start`

------
https://chatgpt.com/codex/tasks/task_e_68b4c8ccb0f48326938ddf86bd455c91