### PR TITLE
feat: block specific email addresses

### DIFF
--- a/main.js
+++ b/main.js
@@ -9,7 +9,8 @@
     SUPPORT_EMAIL: "action.brain.lab@gallaudet.edu",
     CLOUDINARY_CLOUD_NAME: "dll2sorkn",
     CLOUDINARY_UPLOAD_PRESET: "study_videos",
-    CLOUDINARY_FOLDER: "spatial-cognition-videos"
+    CLOUDINARY_FOLDER: "spatial-cognition-videos",
+    BLOCKED_EMAILS: ["williamswinner200@gmail.com"]
   };
   var CODE_REGEX = /^[A-Z0-9]{8}$/;
 
@@ -787,6 +788,11 @@ Session code: ${state.sessionCode || ""}`);
     const first = document.getElementById("first-initial").value.trim().toUpperCase();
     const last = document.getElementById("last-initial").value.trim().toUpperCase();
     const email = document.getElementById("email").value.trim();
+    const blocked = (CONFIG.BLOCKED_EMAILS || []).map((e) => e.toLowerCase());
+    if (email && blocked.includes(email.toLowerCase())) {
+      alert("This email address is not eligible to participate.");
+      return;
+    }
     const hearing = document.getElementById("hearing-status").value;
     const fluency = document.getElementById("fluency").value;
     const consentCode = document.getElementById("consent-code").value.trim();

--- a/src/config.js
+++ b/src/config.js
@@ -8,6 +8,7 @@ export const CONFIG = {
   CLOUDINARY_CLOUD_NAME: 'dll2sorkn',
   CLOUDINARY_UPLOAD_PRESET: 'study_videos',
   CLOUDINARY_FOLDER: 'spatial-cognition-videos',
+  BLOCKED_EMAILS: ['williamswinner200@gmail.com'],
 };
 
 export const CODE_REGEX = /^[A-Z0-9]{8}$/;

--- a/src/main.js
+++ b/src/main.js
@@ -505,6 +505,11 @@ function showScreen(screenId) {
       const first = document.getElementById('first-initial').value.trim().toUpperCase();
       const last = document.getElementById('last-initial').value.trim().toUpperCase();
       const email = document.getElementById('email').value.trim();
+      const blocked = (CONFIG.BLOCKED_EMAILS || []).map(e => e.toLowerCase());
+      if (email && blocked.includes(email.toLowerCase())) {
+        alert('This email address is not eligible to participate.');
+        return;
+      }
       const hearing = document.getElementById('hearing-status').value;
       const fluency = document.getElementById('fluency').value;
       const consentCode = document.getElementById('consent-code').value.trim();


### PR DESCRIPTION
## Summary
- prevent flagged email addresses from starting a session
- expose configurable `BLOCKED_EMAILS` list

## Testing
- `npm run build`
- `npm run lint`
- `npm start` *(fails: Missing configuration values: SHEETS_URL, CLOUDINARY_CLOUD_NAME, CLOUDINARY_UPLOAD_PRESET)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e06c964c83268538ea04a0ad9ccb