### PR TITLE
feat: block mobile devices without consent code

### DIFF
--- a/main.js
+++ b/main.js
@@ -797,6 +797,10 @@ Session code: ${state.sessionCode || ""}`);
     const fluency = document.getElementById("fluency").value;
     const consentCode = document.getElementById("consent-code").value.trim();
     const consent = document.getElementById("consent-confirm").checked;
+    if (isMobileDevice() && !consentCode) {
+      alert("Phones and tablets require the consent access code.");
+      return;
+    }
     if (!first || !last || !hearing || !fluency || !consentCode || !consent) {
       alert("Please complete all fields and confirm consent");
       return;

--- a/src/main.js
+++ b/src/main.js
@@ -514,7 +514,14 @@ function showScreen(screenId) {
       const fluency = document.getElementById('fluency').value;
       const consentCode = document.getElementById('consent-code').value.trim();
       const consent = document.getElementById('consent-confirm').checked;
-      if (!first || !last || !hearing || !fluency || !consentCode || !consent) { alert('Please complete all fields and confirm consent'); return; }
+      if (isMobileDevice() && !consentCode) {
+        alert('Phones and tablets require the consent access code.');
+        return;
+      }
+      if (!first || !last || !hearing || !fluency || !consentCode || !consent) {
+        alert('Please complete all fields and confirm consent');
+        return;
+      }
 
       if (isMobileDevice()) {
         const proceed = confirm(


### PR DESCRIPTION
## Summary
- disallow session creation on phones and tablets unless a consent access code is entered
- rebuild browser bundle

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b593eb2fec8326ad8723cf7e4d6ca8