### PR TITLE
Require consent code on mobile before accessing front page

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,6 +166,42 @@
     .button.skip:hover:not(:disabled) { background: var(--gray-300); }
     .button-group { display: flex; gap: 10px; margin: 20px 0; flex-wrap: wrap; justify-content: center; }
 
+    /* Mobile consent overlay */
+    #mobile-consent-overlay {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(255,255,255,0.95);
+      display: none;
+      align-items: center;
+      justify-content: center;
+      z-index: 1000;
+    }
+    #mobile-consent-overlay.active { display: flex; }
+    #mobile-consent-overlay .overlay-box {
+      background: white;
+      padding: 20px;
+      border-radius: 12px;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+      text-align: center;
+      max-width: 300px;
+      width: 90%;
+    }
+    #mobile-consent-overlay input {
+      width: 100%;
+      padding: 12px;
+      border: 2px solid var(--gray-300);
+      border-radius: 8px;
+      font-size: 16px;
+      margin-top: 10px;
+    }
+    #mobile-consent-overlay .button {
+      margin-top: 10px;
+      width: 100%;
+    }
+
     /* Session widget */
     .session-widget { background: linear-gradient(135deg, #2563eb20, #1d4ed820); border-radius: 10px; padding: 20px; margin-bottom: 30px; display: none; }
     .session-widget.active { display: block; }
@@ -272,6 +308,13 @@
 
 </head>
 <body>
+  <div id="mobile-consent-overlay">
+    <div class="overlay-box">
+      <p>Phones and tablets require the consent access code to continue.</p>
+      <input type="text" id="mobile-consent-input" placeholder="e.g., ABC123" />
+      <button id="mobile-consent-submit" class="button">Continue</button>
+    </div>
+  </div>
   <div class="container">
     <div class="header">
       <h1>Spatial Cognition & Sign Language Research Study</h1>

--- a/main.js
+++ b/main.js
@@ -716,6 +716,27 @@ Session code: ${state.sessionCode || ""}`);
   </ul>
 `;
       }
+      const overlay = document.getElementById("mobile-consent-overlay");
+      if (overlay) {
+        overlay.classList.add("active");
+        const submit = document.getElementById("mobile-consent-submit");
+        if (submit) {
+          submit.addEventListener("click", () => {
+            const codeInput = document.getElementById("mobile-consent-input");
+            const code = codeInput ? codeInput.value.trim() : "";
+            if (!code) {
+              alert("Consent access code is required.");
+              return;
+            }
+            const mainInput = document.getElementById("consent-code");
+            if (mainInput) {
+              mainInput.value = code;
+              validateInitials({ target: mainInput });
+            }
+            overlay.classList.remove("active");
+          });
+        }
+      }
     }
   }
   if (document.readyState === "loading") {

--- a/src/main.js
+++ b/src/main.js
@@ -416,6 +416,28 @@ function init() {
   </ul>
 `;
     }
+
+    const overlay = document.getElementById('mobile-consent-overlay');
+    if (overlay) {
+      overlay.classList.add('active');
+      const submit = document.getElementById('mobile-consent-submit');
+      if (submit) {
+        submit.addEventListener('click', () => {
+          const codeInput = document.getElementById('mobile-consent-input');
+          const code = codeInput ? codeInput.value.trim() : '';
+          if (!code) {
+            alert('Consent access code is required.');
+            return;
+          }
+          const mainInput = document.getElementById('consent-code');
+          if (mainInput) {
+            mainInput.value = code;
+            validateInitials({ target: mainInput });
+          }
+          overlay.classList.remove('active');
+        });
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Add mobile consent overlay to require access code on phones and tablets
- Wire overlay into initialization logic to block page access until code entered
- Rebuild bundled `main.js`

## Testing
- `npm run lint`
- `npm run build`
- `npm start` *(fails: Missing configuration values)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c89baf388326a9b51b78eec02d51