### PR TITLE
Require consent code for mobile devices before page access

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,14 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Spatial Cognition & Sign Language Research Study</title>
+  <script>
+    const hasTouch = ('ontouchstart' in window) || navigator.maxTouchPoints > 0 || navigator.msMaxTouchPoints > 0;
+    const mobileUA = /Android|webOS|iPhone|iPad|iPod|Mobile|Tablet/i.test(navigator.userAgent);
+    const isSmallScreen = window.innerWidth <= 1024;
+    if (hasTouch && (mobileUA || isSmallScreen)) {
+      document.documentElement.classList.add('mobile');
+    }
+  </script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@uploadcare/file-uploader@1/web/uc-file-uploader-regular.min.css" />
   <script type="module">
     import * as UC from "https://cdn.jsdelivr.net/npm/@uploadcare/file-uploader@1/web/uc-file-uploader-regular.min.js";
@@ -179,7 +187,7 @@
       justify-content: center;
       z-index: 1000;
     }
-    #mobile-consent-overlay.active { display: flex; }
+    html.mobile #mobile-consent-overlay { display: flex; }
     #mobile-consent-overlay .overlay-box {
       background: white;
       padding: 20px;

--- a/main.js
+++ b/main.js
@@ -718,7 +718,6 @@ Session code: ${state.sessionCode || ""}`);
       }
       const overlay = document.getElementById("mobile-consent-overlay");
       if (overlay) {
-        overlay.classList.add("active");
         const submit = document.getElementById("mobile-consent-submit");
         if (submit) {
           submit.addEventListener("click", () => {
@@ -733,7 +732,7 @@ Session code: ${state.sessionCode || ""}`);
               mainInput.value = code;
               validateInitials({ target: mainInput });
             }
-            overlay.classList.remove("active");
+            overlay.style.display = "none";
           });
         }
       }

--- a/src/main.js
+++ b/src/main.js
@@ -419,7 +419,6 @@ function init() {
 
     const overlay = document.getElementById('mobile-consent-overlay');
     if (overlay) {
-      overlay.classList.add('active');
       const submit = document.getElementById('mobile-consent-submit');
       if (submit) {
         submit.addEventListener('click', () => {
@@ -434,7 +433,7 @@ function init() {
             mainInput.value = code;
             validateInitials({ target: mainInput });
           }
-          overlay.classList.remove('active');
+          overlay.style.display = 'none';
         });
       }
     }


### PR DESCRIPTION
## Summary
- Detect mobile or tablet devices early and flag HTML for mobile-specific behavior
- Only display welcome page after mobile users enter the consent access code
- Update compiled bundle

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5ca43ead08326939065c30b8b6d0f