### PR TITLE
Expand embedded tasks to full size on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -313,6 +313,8 @@
     html.df-mode .container { width:100vw; height:100vh; border-radius:0; box-shadow:none; }
     html.df-mode .header, html.df-mode .footer, html.df-mode #task-instructions { display:none !important; }
     html.df-mode .embed-frame { height: calc(100vh - 52px); }
+    html.df-mode .content { padding:0; }
+    html.df-mode .embed-shell { margin:0; border-radius:0; border:none; }
 
     /* Responsive */
     @media (max-width: 768px) {

--- a/main.js
+++ b/main.js
@@ -1175,7 +1175,9 @@ Session code: ${state.sessionCode || ""}`);
         } catch (e) {
         }
       }, 50);
-      if (!state.isMobile) {
+      if (state.isMobile) {
+        enterDistractionFree();
+      } else {
         try {
           if (fsShell.requestFullscreen) {
             await fsShell.requestFullscreen({ navigationUI: "hide" }).catch(() => {

--- a/src/main.js
+++ b/src/main.js
@@ -915,7 +915,9 @@ const reqs = (TASKS[taskCode] && TASKS[taskCode].requirements) || '—';
 
         setTimeout(() => { try { iframe.focus(); } catch(e) {} }, 50);
 
-        if (!state.isMobile) {
+        if (state.isMobile) {
+          enterDistractionFree();
+        } else {
           try {
             if (fsShell.requestFullscreen) { await fsShell.requestFullscreen({ navigationUI: 'hide' }).catch(() => {}); }
             else if (fsShell.webkitRequestFullscreen) { fsShell.webkitRequestFullscreen(); }


### PR DESCRIPTION
## Summary
- Trigger distraction-free mode for embedded tasks on mobile devices
- Remove padding and borders in distraction-free mode so tasks occupy the full viewport
- Rebuild main.js

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be3347547883269b447c017312c96c