### PR TITLE
Add ready-to-start flow with optional full-size mode

### DIFF
--- a/main.js
+++ b/main.js
@@ -1127,18 +1127,19 @@ Session code: ${state.sessionCode || ""}`);
   <details style="margin-top:10px;"><summary style="cursor:pointer;">More info / troubleshooting</summary>
     <ul style="margin:8px 0 0 20px; text-align:left;">
       <li>If the game doesn't respond, click inside it once to give it keyboard focus.</li>
-      <li>If fullscreen doesn't work on your device, we'll switch to a distraction-free view.</li>
+      <li>If Full size doesn't work on your device, we'll switch to a distraction-free view.</li>
     </ul>
   </details>
 `;
     const content = document.getElementById("task-content");
-    const startText = state.isMobile ? "When you click <strong>Continue</strong>, the task will appear below. When you're finished, click <em>I'm finished \u2014 Continue</em>." : "When you click <strong>Continue</strong>, the task will open in fullscreen. When you're finished, click <em>I'm finished \u2014 Continue</em>.";
-    const exitLabel = state.isMobile ? "Close task" : "Exit fullscreen";
+    const actionWord = state.isMobile ? "tap" : "click";
+    const startText = `When you ${actionWord} <strong>Ready to start</strong>, the task will appear below. ${state.isMobile ? "Tap" : "Click"} <em>Full size</em> for a distraction-free view. Leaving Full size will pause your task.`;
+    const exitLabel = "Exit full size";
     content.innerHTML = `
   <div class="card" id="prestart">
     <p>${startText}</p>
     <div class="button-group" style="margin-top:12px;">
-      <button class="button" id="start-embed">Continue</button>
+      <button class="button" id="start-embed">Ready to start</button>
       <button class="button outline" type="button" onclick="openSupportEmail('${taskCode}')">Report Technical Issue Instead</button>
       ${task.canSkip ? `<button class="button skip" onclick="showSkipDialog('${taskCode}')" title="Please try the task first or email ${CONFIG.SUPPORT_EMAIL} for help">Unable to complete</button>` : ""}
     </div>
@@ -1148,8 +1149,9 @@ Session code: ${state.sessionCode || ""}`);
     <div class="fs-toolbar" id="fs-toolbar">
       <div>${task.name}</div>
       <div class="actions">
+        <button class="button secondary" id="fs-btn">Full size</button>
         <button class="button success" id="finish-btn" disabled>I'm finished \u2014 Continue</button>
-        <button class="button secondary" id="exit-btn">${exitLabel}</button>
+        <button class="button secondary" id="exit-btn" style="display:none;">${exitLabel}</button>
       </div>
     </div>
     <iframe id="${iframeId}" class="embed-frame" src="${url}" allow="fullscreen; gamepad; xr-spatial-tracking" allowfullscreen></iframe>
@@ -1160,13 +1162,14 @@ Session code: ${state.sessionCode || ""}`);
     const fsShell = document.getElementById("fs-shell");
     const finishBtn = document.getElementById("finish-btn");
     const exitBtn = document.getElementById("exit-btn");
+    const fsBtn = document.getElementById("fs-btn");
     const prestart = document.getElementById("prestart");
     const iframe = document.getElementById(iframeId);
     iframe.addEventListener("focus", () => taskTimer.recordActivity());
     const enableFinish = () => {
       finishBtn.disabled = false;
     };
-    async function goFullscreen() {
+    async function startEmbed() {
       prestart.style.display = "none";
       fsShell.style.display = "block";
       setTimeout(() => {
@@ -1175,9 +1178,10 @@ Session code: ${state.sessionCode || ""}`);
         } catch (e) {
         }
       }, 50);
-      if (state.isMobile) {
-        enterDistractionFree();
-      } else {
+      setTimeout(enableFinish, 6e3);
+    }
+    async function showFullSize() {
+      if (!state.isMobile) {
         try {
           if (fsShell.requestFullscreen) {
             await fsShell.requestFullscreen({ navigationUI: "hide" }).catch(() => {
@@ -1192,16 +1196,22 @@ Session code: ${state.sessionCode || ""}`);
         } catch (e) {
           enterDistractionFree();
         }
+      } else {
+        enterDistractionFree();
       }
-      setTimeout(enableFinish, 6e3);
+      if (fsBtn) fsBtn.style.display = "none";
+      exitBtn.style.display = "";
     }
     function leaveFullscreenModes() {
       if (document.fullscreenElement) document.exitFullscreen().catch(() => {
       });
       if (document.webkitFullscreenElement && document.webkitExitFullscreen) document.webkitExitFullscreen();
       exitDistractionFree();
+      if (fsBtn) fsBtn.style.display = "";
+      exitBtn.style.display = "none";
     }
-    document.getElementById("start-embed").onclick = goFullscreen;
+    document.getElementById("start-embed").onclick = startEmbed;
+    if (fsBtn) fsBtn.onclick = showFullSize;
     finishBtn.onclick = () => {
       leaveFullscreenModes();
       completeTask(taskCode);
@@ -1210,17 +1220,22 @@ Session code: ${state.sessionCode || ""}`);
       leaveFullscreenModes();
       fsShell.scrollIntoView({ behavior: "smooth", block: "start" });
       enableFinish();
+      pauseStudy();
     };
     const loadTimeout = setTimeout(() => {
       const note = document.createElement("div");
       note.className = "embed-note";
-      note.textContent = "Still loading\u2026 if nothing appears soon, try exiting fullscreen and re-entering.";
+      note.textContent = "Still loading\u2026 if nothing appears soon, try exiting Full size and re-entering.";
       fsShell.appendChild(note);
     }, 7e3);
     iframe.addEventListener("load", () => clearTimeout(loadTimeout), { once: true });
     document.addEventListener("keydown", function escHandler(ev) {
       if (ev.key === "Escape") {
-        setTimeout(leaveFullscreenModes, 0);
+        setTimeout(() => {
+          leaveFullscreenModes();
+          fsShell.scrollIntoView({ behavior: "smooth", block: "start" });
+          pauseStudy();
+        }, 0);
         document.removeEventListener("keydown", escHandler);
       }
     });


### PR DESCRIPTION
## Summary
- Expand the optional Full size view to desktop users and mention the button for everyone
- Replace automatic fullscreen with a toolbar Full size button that toggles fullscreen or distraction-free modes

## Testing
- `npm run lint`
- `npm run build`
- `npm start` *(fails: Missing configuration values: SHEETS_URL, CLOUDINARY_CLOUD_NAME, CLOUDINARY_UPLOAD_PRESET)*

------
https://chatgpt.com/codex/tasks/task_e_68be3546f9888326b81cbaddcedbbc1a