### PR TITLE
Open embedded tasks externally on mobile

### DIFF
--- a/main.js
+++ b/main.js
@@ -1133,6 +1133,41 @@ Session code: ${state.sessionCode || ""}`);
 `;
     const content = document.getElementById("task-content");
     const actionWord = state.isMobile ? "tap" : "click";
+    if (state.isMobile) {
+      const startText2 = `When you ${actionWord} <strong>Open Task</strong>, the task will open in a new tab. Return here when finished and ${actionWord} <em>I'm finished \u2014 Continue</em>.`;
+      content.innerHTML = `
+  <div class="card" id="prestart">
+    <p>${startText2}</p>
+    <div class="button-group" style="margin-top:12px;">
+      <button class="button" id="start-embed">Open Task</button>
+      <button class="button outline" type="button" onclick="openSupportEmail('${taskCode}')">Report Technical Issue Instead</button>
+      ${task.canSkip ? `<button class="button skip" onclick="showSkipDialog('${taskCode}')" title="Please try the task first or email ${CONFIG.SUPPORT_EMAIL} for help">Unable to complete</button>` : ""}
+    </div>
+  </div>
+
+  <div class="embed-shell fs-shell" id="fs-shell" style="display:none;">
+    <div class="fs-toolbar" id="fs-toolbar">
+      <div>${task.name}</div>
+      <div class="actions">
+        <button class="button success" id="finish-btn" disabled>I'm finished \u2014 Continue</button>
+      </div>
+    </div>
+    <div class="embed-note">The task opened in a new tab. Return here when finished.</div>
+  </div>
+`;
+      showScreen("task-screen");
+      const prestart2 = document.getElementById("prestart");
+      const fsShell2 = document.getElementById("fs-shell");
+      const finishBtn2 = document.getElementById("finish-btn");
+      document.getElementById("start-embed").onclick = () => {
+        openEmbedInNewTab(taskCode);
+        prestart2.style.display = "none";
+        fsShell2.style.display = "block";
+        finishBtn2.disabled = false;
+      };
+      finishBtn2.onclick = () => completeTask(taskCode);
+      return;
+    }
     const startText = `When you ${actionWord} <strong>Ready to start</strong>, the task will appear below. ${state.isMobile ? "Tap" : "Click"} <em>Full size</em> for a distraction-free view. Leaving Full size will pause your task.`;
     const exitLabel = "Exit full size";
     content.innerHTML = `

--- a/src/main.js
+++ b/src/main.js
@@ -872,6 +872,45 @@ const reqs = (TASKS[taskCode] && TASKS[taskCode].requirements) || '—';
 
       const content = document.getElementById('task-content');
       const actionWord = state.isMobile ? 'tap' : 'click';
+
+      if (state.isMobile) {
+        const startText = `When you ${actionWord} <strong>Open Task</strong>, the task will open in a new tab. Return here when finished and ${actionWord} <em>I'm finished — Continue</em>.`;
+        content.innerHTML = `
+  <div class="card" id="prestart">
+    <p>${startText}</p>
+    <div class="button-group" style="margin-top:12px;">
+      <button class="button" id="start-embed">Open Task</button>
+      <button class="button outline" type="button" onclick="openSupportEmail('${taskCode}')">Report Technical Issue Instead</button>
+      ${task.canSkip ? `<button class="button skip" onclick="showSkipDialog('${taskCode}')" title="Please try the task first or email ${CONFIG.SUPPORT_EMAIL} for help">Unable to complete</button>` : ''}
+    </div>
+  </div>
+
+  <div class="embed-shell fs-shell" id="fs-shell" style="display:none;">
+    <div class="fs-toolbar" id="fs-toolbar">
+      <div>${task.name}</div>
+      <div class="actions">
+        <button class="button success" id="finish-btn" disabled>I'm finished — Continue</button>
+      </div>
+    </div>
+    <div class="embed-note">The task opened in a new tab. Return here when finished.</div>
+  </div>
+`;
+
+        showScreen('task-screen');
+
+        const prestart = document.getElementById('prestart');
+        const fsShell = document.getElementById('fs-shell');
+        const finishBtn = document.getElementById('finish-btn');
+        document.getElementById('start-embed').onclick = () => {
+          openEmbedInNewTab(taskCode);
+          prestart.style.display = 'none';
+          fsShell.style.display = 'block';
+          finishBtn.disabled = false;
+        };
+        finishBtn.onclick = () => completeTask(taskCode);
+        return;
+      }
+
       const startText = `When you ${actionWord} <strong>Ready to start</strong>, the task will appear below. ${state.isMobile ? 'Tap' : 'Click'} <em>Full size</em> for a distraction-free view. Leaving Full size will pause your task.`;
       const exitLabel = 'Exit full size';
       content.innerHTML = `


### PR DESCRIPTION
## Summary
- Avoid iPhone browser crashes by opening embedded tasks in a new tab on mobile devices
- Compile updated bundle

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be46224ee88326bfc15017e293581b