### PR TITLE
Remove consent access code requirement

### DIFF
--- a/google-apps-script.gs
+++ b/google-apps-script.gs
@@ -191,7 +191,7 @@ function doPost(e) {
       case 'consent_verified':
         withDocLock_(function () {
           setConsentVerify_(ss, data.sessionCode || 'none', data.type, 'Verified',
-            data.method || 'unknown', data.codeSuffix || data.ridSuffix || '', data.timestamp);
+            data.method || 'unknown', data.timestamp);
           logSessionEvent(ss, {
             sessionCode: data.sessionCode || '',
             eventType: 'Consent Verified',
@@ -204,7 +204,7 @@ function doPost(e) {
       case 'consent_affirmed':
         withDocLock_(function () {
           setConsentVerify_(ss, data.sessionCode || 'none', data.type, 'Affirmed',
-            data.method || 'affirmation', '', data.timestamp);
+            data.method || 'affirmation', data.timestamp);
           logSessionEvent(ss, {
             sessionCode: data.sessionCode || '',
             eventType: 'Consent Affirmed',
@@ -473,7 +473,7 @@ function sanitizeInput_(obj) {
 var SESSIONS_HEADERS = [
   'Session Code','Participant ID','Email','Created Date','Last Activity',
   'Total Time (min)','Active Time (min)','Idle Time (min)','Paused Time (min)','Tasks Completed','Status',
-  'Device Type','Consent Status','Consent Source','Consent Code','Consent Timestamp',
+  'Device Type','Consent Status','Consent Source','Consent Timestamp',
   'EEG Status','EEG Scheduled At','EEG Scheduling Source',
   'Hearing Status','Fluency','State JSON'
 ];
@@ -484,7 +484,6 @@ var CONSENT_HEADER_VARIANTS = {
   'Consent 1': 'Consent Status',
   'Consent 2': 'Consent Status',
   'Consent Verify Source': 'Consent Source',
-  'Consent Verify Code': 'Consent Code',
   'Consent Verify Timestamp': 'Consent Timestamp'
 };
 
@@ -2553,18 +2552,17 @@ function ensureConsentColumns_(ss) {
     return {
       status: ensureHeader_('Consent Status'),
       src: ensureHeader_('Consent Source'),
-      code: ensureHeader_('Consent Code'),
       when: ensureHeader_('Consent Timestamp')
     };
   });
 }
 
-function setConsentVerify_(ss, sessionCode, which, status, source, codeSuffix, ts) {
+function setConsentVerify_(ss, sessionCode, which, status, source, ts) {
   if (!sessionCode || sessionCode === 'none') return;
   withDocLock_(function () {
     var sheet = ss.getSheetByName('Sessions');
     if (!sheet) return;
-    var cols = ensureConsentColumns_(ss);
+    ensureConsentColumns_(ss);
 
     var row = findRowBySessionCode_(sheet, sessionCode);
     if (!row) return;
@@ -2573,7 +2571,6 @@ function setConsentVerify_(ss, sessionCode, which, status, source, codeSuffix, t
       'Consent Status': status || 'Verified',
       'Consent Source': source || ''
     };
-    if (codeSuffix) kv['Consent Code'] = codeSuffix;
     kv['Consent Timestamp'] = ts || new Date().toISOString();
 
     setManyByHeader_(sheet, row, kv);
@@ -2704,7 +2701,7 @@ function enforceColumnFormats_(ss) {
   }
 
   // Force text where Sheets loves to "help"
-  ['Tasks Completed','Status','Device Type','Consent Status','Consent Source','Consent Code',
+  ['Tasks Completed','Status','Device Type','Consent Status','Consent Source',
    'EEG Status','EEG Scheduling Source','Hearing Status','Fluency','Email']
     .forEach(function(h){ fmt(h, '@'); });
 

--- a/index.html
+++ b/index.html
@@ -192,41 +192,6 @@
     .button.skip:hover:not(:disabled) { background: var(--gray-300); }
     .button-group { display: flex; gap: 10px; margin: 20px 0; flex-wrap: wrap; justify-content: center; }
 
-    /* Mobile consent overlay */
-    #mobile-consent-overlay {
-      position: fixed;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      background: rgba(255,255,255,0.95);
-      display: none;
-      align-items: center;
-      justify-content: center;
-      z-index: 1000;
-    }
-    html.mobile #mobile-consent-overlay { display: flex; }
-    #mobile-consent-overlay .overlay-box {
-      background: white;
-      padding: 20px;
-      border-radius: 12px;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-      text-align: center;
-      max-width: 300px;
-      width: 90%;
-    }
-    #mobile-consent-overlay input {
-      width: 100%;
-      padding: 12px;
-      border: 2px solid var(--gray-300);
-      border-radius: 8px;
-      font-size: 16px;
-      margin-top: 10px;
-    }
-    #mobile-consent-overlay .button {
-      margin-top: 10px;
-      width: 100%;
-    }
 
     /* Session widget */
     .session-widget { background: linear-gradient(135deg, #2563eb20, #1d4ed820); border-radius: 10px; padding: 20px; margin-bottom: 30px; display: none; }
@@ -336,13 +301,6 @@
 
 </head>
 <body>
-  <div id="mobile-consent-overlay">
-    <div class="overlay-box">
-      <p>Phones and tablets require the consent access code to continue.</p>
-      <input type="text" id="mobile-consent-input" placeholder="e.g., ABC123" />
-      <button id="mobile-consent-submit" class="button">Continue</button>
-    </div>
-  </div>
   <div class="container">
     <div class="header">
       <h1>Spatial Cognition & Sign Language Research Study</h1>
@@ -454,12 +412,7 @@
         <h2>New Participant Registration</h2>
         <p style="color: var(--text-secondary); margin-bottom: 30px;">Create your unique session to track your progress</p>
 
-        <p style="margin-bottom: 20px;">Please confirm you have completed the consent form and enter the access code provided on Qualtrics.</p>
-
-        <div class="form-group">
-          <label for="consent-code">Consent Access Code</label>
-          <input type="text" id="consent-code" placeholder="e.g., ABC123" />
-        </div>
+        <p style="margin-bottom: 20px;">Please confirm you have completed the consent form.</p>
 
         <div class="form-group checkbox">
           <label>

--- a/main.js
+++ b/main.js
@@ -717,26 +717,6 @@ Session code: ${state.sessionCode || ""}`);
   </ul>
 `;
       }
-      const overlay = document.getElementById("mobile-consent-overlay");
-      if (overlay) {
-        const submit = document.getElementById("mobile-consent-submit");
-        if (submit) {
-          submit.addEventListener("click", () => {
-            const codeInput = document.getElementById("mobile-consent-input");
-            const code = codeInput ? codeInput.value.trim() : "";
-            if (!code) {
-              alert("Consent access code is required.");
-              return;
-            }
-            const mainInput = document.getElementById("consent-code");
-            if (mainInput) {
-              mainInput.value = code;
-              validateInitials({ target: mainInput });
-            }
-            overlay.style.display = "none";
-          });
-        }
-      }
     }
   }
   if (document.readyState === "loading") {
@@ -749,7 +729,6 @@ Session code: ${state.sessionCode || ""}`);
     document.getElementById("last-initial").addEventListener("input", validateInitials);
     document.getElementById("hearing-status").addEventListener("change", validateInitials);
     document.getElementById("fluency").addEventListener("change", validateInitials);
-    document.getElementById("consent-code").addEventListener("input", validateInitials);
     document.getElementById("consent-confirm").addEventListener("change", validateInitials);
     document.getElementById("resume-code").addEventListener("input", (e) => {
       e.target.value = e.target.value.toUpperCase();
@@ -764,9 +743,8 @@ Session code: ${state.sessionCode || ""}`);
     const last = document.getElementById("last-initial").value;
     const hearing = document.getElementById("hearing-status").value;
     const fluency = document.getElementById("fluency").value;
-    const consentCode = document.getElementById("consent-code").value;
     const consent = document.getElementById("consent-confirm").checked;
-    document.getElementById("create-session-btn").disabled = !(first && last && hearing && fluency && consentCode && consent);
+    document.getElementById("create-session-btn").disabled = !(first && last && hearing && fluency && consent);
   }
   function showScreen(screenId) {
     document.querySelectorAll(".screen").forEach((s) => s.classList.remove("active"));
@@ -816,13 +794,8 @@ Session code: ${state.sessionCode || ""}`);
     }
     const hearing = document.getElementById("hearing-status").value;
     const fluency = document.getElementById("fluency").value;
-    const consentCode = document.getElementById("consent-code").value.trim();
     const consent = document.getElementById("consent-confirm").checked;
-    if (isMobileDevice() && !consentCode) {
-      alert("Phones and tablets require the consent access code.");
-      return;
-    }
-    if (!first || !last || !hearing || !fluency || !consentCode || !consent) {
+    if (!first || !last || !hearing || !fluency || !consent) {
       alert("Please complete all fields and confirm consent");
       return;
     }
@@ -837,7 +810,6 @@ Session code: ${state.sessionCode || ""}`);
     state.email = email;
     state.hearingStatus = hearing;
     state.fluency = fluency;
-    state.consentCode = consentCode;
     state.consentConfirmed = consent;
     const seed = Math.abs(hashCode(state.sessionCode));
     state.sequenceIndex = seed;
@@ -859,7 +831,6 @@ Session code: ${state.sessionCode || ""}`);
       email: state.email,
       hearingStatus: state.hearingStatus,
       fluency: state.fluency,
-      consentCode: state.consentCode,
       consentConfirmed: state.consentConfirmed,
       deviceType: state.isMobile ? "mobile/tablet" : "desktop",
       timestamp: (/* @__PURE__ */ new Date()).toISOString()

--- a/src/main.js
+++ b/src/main.js
@@ -417,26 +417,6 @@ function init() {
 `;
     }
 
-    const overlay = document.getElementById('mobile-consent-overlay');
-    if (overlay) {
-      const submit = document.getElementById('mobile-consent-submit');
-      if (submit) {
-        submit.addEventListener('click', () => {
-          const codeInput = document.getElementById('mobile-consent-input');
-          const code = codeInput ? codeInput.value.trim() : '';
-          if (!code) {
-            alert('Consent access code is required.');
-            return;
-          }
-          const mainInput = document.getElementById('consent-code');
-          if (mainInput) {
-            mainInput.value = code;
-            validateInitials({ target: mainInput });
-          }
-          overlay.style.display = 'none';
-        });
-      }
-    }
   }
 }
 
@@ -451,7 +431,6 @@ if (document.readyState === 'loading') {
       document.getElementById('last-initial').addEventListener('input', validateInitials);
       document.getElementById('hearing-status').addEventListener('change', validateInitials);
       document.getElementById('fluency').addEventListener('change', validateInitials);
-      document.getElementById('consent-code').addEventListener('input', validateInitials);
       document.getElementById('consent-confirm').addEventListener('change', validateInitials);
       document.getElementById('resume-code').addEventListener('input', e => { e.target.value = e.target.value.toUpperCase(); });
         bindRecordingSkips(showSkipDialog);
@@ -465,9 +444,8 @@ if (document.readyState === 'loading') {
       const last = document.getElementById('last-initial').value;
       const hearing = document.getElementById('hearing-status').value;
       const fluency = document.getElementById('fluency').value;
-      const consentCode = document.getElementById('consent-code').value;
       const consent = document.getElementById('consent-confirm').checked;
-      document.getElementById('create-session-btn').disabled = !(first && last && hearing && fluency && consentCode && consent);
+      document.getElementById('create-session-btn').disabled = !(first && last && hearing && fluency && consent);
     }
 
     // ----- Screens -----
@@ -533,13 +511,8 @@ function showScreen(screenId) {
       }
       const hearing = document.getElementById('hearing-status').value;
       const fluency = document.getElementById('fluency').value;
-      const consentCode = document.getElementById('consent-code').value.trim();
       const consent = document.getElementById('consent-confirm').checked;
-      if (isMobileDevice() && !consentCode) {
-        alert('Phones and tablets require the consent access code.');
-        return;
-      }
-      if (!first || !last || !hearing || !fluency || !consentCode || !consent) {
+      if (!first || !last || !hearing || !fluency || !consent) {
         alert('Please complete all fields and confirm consent');
         return;
       }
@@ -559,7 +532,6 @@ function showScreen(screenId) {
       state.email = email;
       state.hearingStatus = hearing;
       state.fluency = fluency;
-      state.consentCode = consentCode;
       state.consentConfirmed = consent;
 
       // Choose sequence (mobile vs desktop)
@@ -585,7 +557,6 @@ function showScreen(screenId) {
         email: state.email,
         hearingStatus: state.hearingStatus,
         fluency: state.fluency,
-        consentCode: state.consentCode,
         consentConfirmed: state.consentConfirmed,
         deviceType: state.isMobile ? 'mobile/tablet' : 'desktop',
         timestamp: new Date().toISOString()


### PR DESCRIPTION
## Summary
- drop consent access code field and mobile overlay
- simplify session creation logic to only confirm consent
- remove consent code handling from Apps Script and data headers

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c18411a6108326987137f6a05def0a