### PR TITLE
Define Uploadcare public key for uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,5 @@ PORT=<optional port, defaults to 3000>
 ```
 
 Do not commit the `.env` file to version control.
+
+The Uploadcare widget uses the public key `5bbde6a6390e682bbbe7`, which is already configured in the client.

--- a/index.html
+++ b/index.html
@@ -30,6 +30,9 @@
       });
     }
   </script>
+  <script>
+    window.UPLOADCARE_PUBLIC_KEY = '5bbde6a6390e682bbbe7';
+  </script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@uploadcare/file-uploader@1/web/uc-file-uploader-regular.min.css" />
   <script type="module">
     import * as UC from "https://cdn.jsdelivr.net/npm/@uploadcare/file-uploader@1/web/uc-file-uploader-regular.min.js";

--- a/main.js
+++ b/main.js
@@ -10,6 +10,7 @@
     CLOUDINARY_CLOUD_NAME: "dll2sorkn",
     CLOUDINARY_UPLOAD_PRESET: "study_videos",
     CLOUDINARY_FOLDER: "spatial-cognition-videos",
+    UPLOADCARE_PUBLIC_KEY: window.UPLOADCARE_PUBLIC_KEY || "5bbde6a6390e682bbbe7",
     BLOCKED_EMAILS: ["williamswinner200@gmail.com", "alvarezxoxo2@gmail.com", "robertgeorge0045@gmail.com"]
   };
   var CODE_REGEX = /^[A-Z0-9]{8}$/;

--- a/src/config.js
+++ b/src/config.js
@@ -8,6 +8,7 @@ export const CONFIG = {
   CLOUDINARY_CLOUD_NAME: 'dll2sorkn',
   CLOUDINARY_UPLOAD_PRESET: 'study_videos',
   CLOUDINARY_FOLDER: 'spatial-cognition-videos',
+  UPLOADCARE_PUBLIC_KEY: window.UPLOADCARE_PUBLIC_KEY || '5bbde6a6390e682bbbe7',
   BLOCKED_EMAILS: ['williamswinner200@gmail.com', 'alvarezxoxo2@gmail.com', 'robertgeorge0045@gmail.com'],
 };
 


### PR DESCRIPTION
## Summary
- Expose Uploadcare public key in config and HTML for reliable video uploads
- Document public key usage in README

## Testing
- `npm run lint`
- `npm run build`
- `SHEETS_URL=http://example.com CLOUDINARY_CLOUD_NAME=dummy CLOUDINARY_UPLOAD_PRESET=dummy npm start`

------
https://chatgpt.com/codex/tasks/task_e_68c1d5231fe88326b5270ce9c707bd9d